### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,6 +2,9 @@ name: Pylint
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: windows-latest


### PR DESCRIPTION
Potential fix for [https://github.com/chaitu-ycr/py_canoe/security/code-scanning/1](https://github.com/chaitu-ycr/py_canoe/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function. Since the workflow only checks out the code and runs Pylint, it only needs `contents: read` permission. This ensures that the workflow cannot perform any unintended write operations on the repository.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
