### PR TITLE
Add timeout and safer handling for diagnostic requests

### DIFF
--- a/src/py_canoe/core/networks.py
+++ b/src/py_canoe/core/networks.py
@@ -37,9 +37,13 @@ class Networks:
             logger.error(f"❌ Error fetching Diagnostic Devices: {e}")
             return None
 
-    def send_diag_request(self, diag_ecu_qualifier_name: str, request: str, request_in_bytes=True, return_sender_name=False, response_in_bytearray=False) -> Union[str, dict]:
+    def send_diag_request(self, diag_ecu_qualifier_name: str, request: str, request_in_bytes=True, return_sender_name=False, response_in_bytearray=False, timeout: float = 10.0, poll_s: float = 0.01) -> Union[str, dict]:
         try:
-            diag_device: Diagnostic = self.diagnostic_devices.get(diag_ecu_qualifier_name)
+            diag_devices = self.application.networks.diagnostic_devices
+            if not diag_devices or diag_ecu_qualifier_name not in diag_devices:
+                self.application.networks.fetch_diagnostic_devices()
+                diag_devices = self.application.networks.diagnostic_devices
+            diag_device = diag_devices.get(diag_ecu_qualifier_name)
             if diag_device:
                 if request_in_bytes:
                     diag_req_in_bytes = bytearray()
@@ -51,8 +55,19 @@ class Networks:
                     diag_request = diag_device.create_request(request)
                 diag_request.send()
                 logger.info(f'💉 {diag_ecu_qualifier_name}: Diagnostic Request = {request}')
-                while diag_request.pending:
-                    wait(0.01)
+                start_time = time.time()
+                while (
+                    diag_request.responses.count == 0
+                    and (time.time() - start_time) < timeout
+                ):
+                    if (time.time() - start_time) >= timeout:
+                        logger.warning(
+                            f"Diagnostic request timed out after {timeout}s: {request}"
+                        )
+                        return f"ERROR: timeout after {timeout}s"
+                    wait(poll_s)
+                if diag_request.responses.count > 0:
+                    wait(poll_s)
                 diag_responses_dict = {}
                 diag_response_including_sender_name = {}
                 for i in range(1, diag_request.responses.count + 1):
@@ -76,7 +91,11 @@ class Networks:
                         logger.info(f'🟢 {response_sender}: Diagnostic Response = {response_stream_in_str}')
                     else:
                         logger.info(f'🔴 {response_sender}: Diagnostic Response = {response_stream_in_str}')
-                return diag_response_including_sender_name if return_sender_name else diag_response_including_sender_name[diag_ecu_qualifier_name]
+                if return_sender_name:
+                    return diag_response_including_sender_name
+                if diag_ecu_qualifier_name in diag_response_including_sender_name:
+                    return diag_response_including_sender_name[diag_ecu_qualifier_name]
+                return next(iter(diag_response_including_sender_name.values()), "")
             else:
                 logger.warning(f'⚠️ No responses received for request: {request}')
                 return {"error": "No responses received"}


### PR DESCRIPTION
This change fixes an issue where diagnostic requests could hang indefinitely when an ECU failed to respond. The workaround for this was aborting the test run. The function now includes:

- A timeout (default 10s) to prevent blocking the test run
- A small polling interval to avoid busy‑waiting
- Automatic refresh of diagnostic devices if missing
- Safer response handling and clearer error messages

This ensures the function always returns control back to python, even when diagnostics fail, preventing stalled test sequences.

This has been tested and confirmed working with CANoe versions 17 and 18. 