### PR TITLE
Fixed path from self.application.networks.diagnostic_devices to self.diagnostic_devices

### DIFF
--- a/src/py_canoe/core/networks.py
+++ b/src/py_canoe/core/networks.py
@@ -1,3 +1,4 @@
+import time
 from typing import Union
 
 from py_canoe.helpers.common import logger
@@ -39,10 +40,10 @@ class Networks:
 
     def send_diag_request(self, diag_ecu_qualifier_name: str, request: str, request_in_bytes=True, return_sender_name=False, response_in_bytearray=False, timeout: float = 10.0, poll_s: float = 0.01) -> Union[str, dict]:
         try:
-            diag_devices = self.application.networks.diagnostic_devices
+            diag_devices = self.diagnostic_devices
             if not diag_devices or diag_ecu_qualifier_name not in diag_devices:
-                self.application.networks.fetch_diagnostic_devices()
-                diag_devices = self.application.networks.diagnostic_devices
+                self.fetch_diagnostic_devices()
+                diag_devices = self.diagnostic_devices
             diag_device = diag_devices.get(diag_ecu_qualifier_name)
             if diag_device:
                 if request_in_bytes:


### PR DESCRIPTION
Fixed the path to diagnostic devices. This was tested on the CANoe object directly so included application.networks.