### PR TITLE
add get_all_network_names to Networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,17 @@ canoe_inst.add_database(fr"{file_path}\demo_cfg\DBs\sample_databases\XCP.dbc", '
 canoe_inst.remove_database(fr"{file_path}\demo_cfg\DBs\sample_databases\XCP.dbc", 1)
 ```
 
+### get configured network names
+
+```python
+from py_canoe import CANoe, wait
+
+canoe_inst = CANoe()
+canoe_inst.open(canoe_cfg=r'tests\demo_cfg\demo_dev.cfg')
+
+network_names = canoe_inst.application.networks.get_all_network_names()
+```
+
 ### start/stop online logging block
 
 ```python

--- a/src/py_canoe/core/networks.py
+++ b/src/py_canoe/core/networks.py
@@ -22,6 +22,21 @@ class Networks:
     def item(self, index: int) -> Network:
         return Network(self.com_object.Item(index))
 
+    def get_all_network_names(self) -> list[str]:
+        try:
+            count = self.count
+            names = []
+            for i in range(1, count + 1):
+                network = self.item(i)
+                name = network.name
+                if name is not None:
+                    names.append(name)
+            logger.info(f'networks: {names}')
+            return names
+        except Exception as e:
+            logger.error(f"Error retrieving network names: {e}")
+            return []
+
     def fetch_diagnostic_devices(self):
         try:
             for i in range(1, self.count + 1):

--- a/tests/test_py_canoe.py
+++ b/tests/test_py_canoe.py
@@ -262,6 +262,13 @@ class TestStandalonePyCanoe:
         assert isinstance(result, bool)
         assert result is True
 
+    def test_get_all_network_names(self):
+        self.canoe_inst.open(canoe_cfg=self.canoe_cfg_dev, visible=True, auto_save=False, prompt_user=False)
+        names = self.canoe_inst.application.networks.get_all_network_names()
+        assert isinstance(names, list)
+        assert len(names) > 0
+        assert all(isinstance(n, str) for n in names)
+
     def test_logging(self):
         self.canoe_inst.open(canoe_cfg=self.canoe_cfg_online_setup)
         logging_blocks = self.canoe_inst.get_logging_blocks()

--- a/tests/test_unit_network_names.py
+++ b/tests/test_unit_network_names.py
@@ -1,0 +1,59 @@
+from unittest.mock import MagicMock, PropertyMock
+from py_canoe.core.networks import Networks
+
+
+class TestGetAllNetworkNames:
+    def _make_networks(self, names):
+        com = MagicMock()
+        com.Count = len(names)
+
+        def item_side_effect(index):
+            net = MagicMock()
+            net.Name = names[index - 1]
+            return net
+
+        com.Item.side_effect = item_side_effect
+        networks = Networks.__new__(Networks)
+        networks.com_object = com
+        networks.diagnostic_devices = {}
+        return networks
+
+    def test_returns_all_names(self):
+        networks = self._make_networks(["CAN_1", "LIN_1", "Ethernet_1"])
+        result = networks.get_all_network_names()
+        assert result == ["CAN_1", "LIN_1", "Ethernet_1"]
+
+    def test_includes_empty_string_names(self):
+        networks = self._make_networks(["CAN_1", "", "LIN_1"])
+        result = networks.get_all_network_names()
+        assert result == ["CAN_1", "", "LIN_1"]
+
+    def test_skips_none_names(self):
+        com = MagicMock()
+        com.Count = 2
+
+        def item_side_effect(index):
+            net = MagicMock()
+            net.Name = None if index == 1 else "CAN_1"
+            return net
+
+        com.Item.side_effect = item_side_effect
+        networks = Networks.__new__(Networks)
+        networks.com_object = com
+        networks.diagnostic_devices = {}
+        result = networks.get_all_network_names()
+        assert result == ["CAN_1"]
+
+    def test_returns_empty_list_when_no_networks(self):
+        networks = self._make_networks([])
+        result = networks.get_all_network_names()
+        assert result == []
+
+    def test_returns_empty_list_on_exception(self):
+        com = MagicMock()
+        type(com).Count = PropertyMock(side_effect=Exception("COM error"))
+        networks = Networks.__new__(Networks)
+        networks.com_object = com
+        networks.diagnostic_devices = {}
+        result = networks.get_all_network_names()
+        assert result == []


### PR DESCRIPTION
## Summary                                                                                                                           
  Add `get_all_network_names()` method to retrieve all configured network names from CANoe configuration.
                                                                                                                                       
  ## Changes                                                
  - New method in `Networks` class returns list of network names
  - Snapshots count before iteration to avoid race conditions
  - Filters None values, preserves empty strings
  - Includes unit tests and README example

  ## Usage
  ```python
  canoe_inst = CANoe()
  canoe_inst.open(canoe_cfg=r'demo.cfg')
  names = canoe_inst.application.networks.get_all_network_names()
  # Returns: ['CAN_1', 'LIN_1', 'Ethernet_1']

  Tests

  5 unit tests + integration test passing