### PR TITLE
expose simulation setup buses and db paths via Bus

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,18 @@ canoe_inst.open(canoe_cfg=r'tests\demo_cfg\demo_dev.cfg')
 network_names = canoe_inst.application.networks.get_all_network_names()
 ```
 
+### get configured simulation buses and database paths
+
+```python
+from py_canoe import CANoe, wait
+
+canoe_inst = CANoe()
+canoe_inst.open(canoe_cfg=r'tests\demo_cfg\demo_dev.cfg')
+
+bus_names = canoe_inst.application.bus.get_simulation_bus_names()
+db_paths = canoe_inst.application.bus.get_simulation_database_paths()
+```
+
 ### start/stop online logging block
 
 ```python

--- a/src/py_canoe/__init__.py
+++ b/src/py_canoe/__init__.py
@@ -1,2 +1,6 @@
-from py_canoe.canoe import CANoe
-from py_canoe.helpers.common import wait
+from py_canoe.canoe import CANoe as CANoe
+from py_canoe.helpers.common import wait as wait
+from py_canoe.exceptions import (
+    PyCanoeError as PyCanoeError,
+    ConfigurationNotLoadedError as ConfigurationNotLoadedError,
+)

--- a/src/py_canoe/core/bus.py
+++ b/src/py_canoe/core/bus.py
@@ -10,6 +10,7 @@ from py_canoe.core.child_elements.replay_collection import ReplayCollection
 from py_canoe.core.child_elements.security_configuration import SecurityConfiguration
 from py_canoe.core.child_elements.signals import Signal
 from py_canoe.core.database_utils.db import fetch_database_info
+from py_canoe.exceptions import ConfigurationNotLoadedError
 from py_canoe.helpers.common import logger, wait
 
 
@@ -160,6 +161,35 @@ class Bus:
         except Exception as e:
             logger.error(f"❌ Error retrieving {bus} bus nodes information: {e}")
             return {}
+
+    def get_simulation_bus_names(self) -> list[str]:
+        try:
+            sim_buses = self.app.configuration.simulation_setup.buses
+            bus_names: list[str] = []
+            for i in range(1, sim_buses.count + 1):
+                sim_bus = sim_buses.item(i)
+                if sim_bus.name is not None:
+                    bus_names.append(sim_bus.name)
+            logger.info(f'📜 simulation buses: {bus_names}')
+            return bus_names
+        except Exception as e:
+            raise ConfigurationNotLoadedError(f"Cannot access simulation buses: {e}") from e
+
+    def get_simulation_database_paths(self) -> list[str]:
+        try:
+            sim_buses = self.app.configuration.simulation_setup.buses
+            paths: list[str] = []
+            for i in range(1, sim_buses.count + 1):
+                sim_bus = sim_buses.item(i)
+                dbs = sim_bus.databases
+                for j in range(1, dbs.count + 1):
+                    db = dbs.item(j)
+                    if db.full_name is not None:
+                        paths.append(db.full_name)
+            logger.info(f'📜 simulation database paths: {paths}')
+            return paths
+        except Exception as e:
+            raise ConfigurationNotLoadedError(f"Cannot access simulation databases: {e}") from e
 
     def get_signal_value(self, bus: str, channel: int, message: str, signal: str, raw_value: bool = False) -> Union[int, float, None]:
         try:

--- a/src/py_canoe/core/child_elements/simulation_setup.py
+++ b/src/py_canoe/core/child_elements/simulation_setup.py
@@ -1,0 +1,57 @@
+class SimulationSetup:
+    def __init__(self, com_object):
+        self.com_object = com_object
+
+    @property
+    def buses(self) -> 'SimulationBuses':
+        return SimulationBuses(self.com_object.Buses)
+
+
+class SimulationBuses:
+    def __init__(self, com_object):
+        self.com_object = com_object
+
+    @property
+    def count(self) -> int:
+        return self.com_object.Count
+
+    def item(self, index: int) -> 'SimulationBus':
+        return SimulationBus(self.com_object.Item(index))
+
+
+class SimulationBus:
+    def __init__(self, com_object):
+        self.com_object = com_object
+
+    @property
+    def name(self) -> str:
+        return self.com_object.Name
+
+    @property
+    def databases(self) -> 'SimulationBusDatabases':
+        return SimulationBusDatabases(self.com_object.Databases)
+
+
+class SimulationBusDatabases:
+    def __init__(self, com_object):
+        self.com_object = com_object
+
+    @property
+    def count(self) -> int:
+        return self.com_object.Count
+
+    def item(self, index: int) -> 'SimulationBusDatabase':
+        return SimulationBusDatabase(self.com_object.Item(index))
+
+
+class SimulationBusDatabase:
+    def __init__(self, com_object):
+        self.com_object = com_object
+
+    @property
+    def full_name(self) -> str:
+        return self.com_object.FullName
+
+    @property
+    def name(self) -> str:
+        return self.com_object.Name

--- a/src/py_canoe/core/configuration.py
+++ b/src/py_canoe/core/configuration.py
@@ -14,6 +14,7 @@ from py_canoe.core.child_elements.general_setup import GeneralSetup
 from py_canoe.core.child_elements.measurement_setup import MeasurementSetup
 from py_canoe.core.child_elements.database_setup import Databases
 from py_canoe.core.child_elements.replay_collection import ReplayCollection
+from py_canoe.core.child_elements.simulation_setup import SimulationSetup
 from py_canoe.core.child_elements.test_configurations import TestConfigurations
 from py_canoe.core.child_elements.test_setup import TestSetup
 from py_canoe.helpers.common import logger, wait
@@ -141,7 +142,9 @@ class Configuration:
 
     # Sensor
 
-    # SimulationSetup
+    @property
+    def simulation_setup(self) -> 'SimulationSetup':
+        return SimulationSetup(self.com_object.SimulationSetup)
 
     # StandaloneMode
 

--- a/src/py_canoe/exceptions.py
+++ b/src/py_canoe/exceptions.py
@@ -1,0 +1,13 @@
+class PyCanoeError(Exception):
+    """Base exception for py_canoe errors."""
+    pass
+
+
+class NamespaceNotFoundError(PyCanoeError):
+    """Raised when a requested namespace does not exist."""
+    pass
+
+
+class ConfigurationNotLoadedError(PyCanoeError):
+    """Raised when no configuration is loaded or simulation setup is inaccessible."""
+    pass

--- a/tests/test_py_canoe.py
+++ b/tests/test_py_canoe.py
@@ -269,6 +269,20 @@ class TestStandalonePyCanoe:
         assert len(names) > 0
         assert all(isinstance(n, str) for n in names)
 
+    def test_simulation_bus_names(self):
+        self.canoe_inst.open(canoe_cfg=self.canoe_cfg_dev, visible=True, auto_save=False, prompt_user=False)
+        names = self.canoe_inst.application.bus.get_simulation_bus_names()
+        assert isinstance(names, list)
+        assert len(names) > 0
+        assert all(isinstance(n, str) for n in names)
+
+    def test_simulation_database_paths(self):
+        self.canoe_inst.open(canoe_cfg=self.canoe_cfg_dev, visible=True, auto_save=False, prompt_user=False)
+        paths = self.canoe_inst.application.bus.get_simulation_database_paths()
+        assert isinstance(paths, list)
+        assert len(paths) > 0
+        assert all(isinstance(p, str) for p in paths)
+
     def test_logging(self):
         self.canoe_inst.open(canoe_cfg=self.canoe_cfg_online_setup)
         logging_blocks = self.canoe_inst.get_logging_blocks()

--- a/tests/test_unit_simulation_setup_buses.py
+++ b/tests/test_unit_simulation_setup_buses.py
@@ -1,0 +1,258 @@
+import pytest
+from unittest.mock import MagicMock, PropertyMock
+from py_canoe.exceptions import ConfigurationNotLoadedError
+from py_canoe.core.child_elements.simulation_setup import (
+    SimulationSetup,
+    SimulationBuses,
+    SimulationBus,
+    SimulationBusDatabases,
+    SimulationBusDatabase,
+)
+
+
+def _make_sim_buses(bus_specs):
+    buses_com = MagicMock()
+    buses_com.Count = len(bus_specs)
+
+    def buses_item(index):
+        spec = bus_specs[index - 1]
+        bus_com = MagicMock()
+        bus_com.Name = spec["name"]
+        dbs_com = MagicMock()
+        dbs_com.Count = len(spec["dbs"])
+
+        def dbs_item(j):
+            db_spec = spec["dbs"][j - 1]
+            db_com = MagicMock()
+            db_com.FullName = db_spec["full_name"]
+            db_com.Name = db_spec["name"]
+            return db_com
+
+        dbs_com.Item.side_effect = dbs_item
+        bus_com.Databases = dbs_com
+        return bus_com
+
+    buses_com.Item.side_effect = buses_item
+
+    sim_buses = SimulationBuses.__new__(SimulationBuses)
+    sim_buses.com_object = buses_com
+    return sim_buses
+
+
+def _make_bus_obj(bus_specs):
+    """Returns a Bus-like object whose app.configuration.simulation_setup.buses uses bus_specs."""
+    from py_canoe.core.bus import Bus
+
+    sim_buses = _make_sim_buses(bus_specs)
+
+    sim_setup = MagicMock(spec=SimulationSetup)
+    type(sim_setup).buses = PropertyMock(return_value=sim_buses)
+
+    app = MagicMock()
+    app.configuration.simulation_setup = sim_setup
+
+    bus_obj = Bus.__new__(Bus)
+    bus_obj.app = app
+    return bus_obj
+
+
+class TestSimulationSetupClasses:
+    def test_simulation_setup_buses_property(self):
+        com = MagicMock()
+        buses_com = MagicMock()
+        com.Buses = buses_com
+        ss = SimulationSetup(com)
+        result = ss.buses
+        assert isinstance(result, SimulationBuses)
+
+    def test_simulation_buses_count(self):
+        com = MagicMock()
+        com.Count = 3
+        sb = SimulationBuses(com)
+        assert sb.count == 3
+
+    def test_simulation_buses_item_returns_simulation_bus(self):
+        inner_com = MagicMock()
+        buses_com = MagicMock()
+        buses_com.Item.return_value = inner_com
+        buses_com.Count = 1
+        sb = SimulationBuses(buses_com)
+        result = sb.item(1)
+        assert isinstance(result, SimulationBus)
+
+    def test_simulation_bus_name(self):
+        com = MagicMock()
+        com.Name = "CAN1"
+        bus = SimulationBus(com)
+        assert bus.name == "CAN1"
+
+    def test_simulation_bus_databases_property(self):
+        dbs_com = MagicMock()
+        com = MagicMock()
+        com.Databases = dbs_com
+        bus = SimulationBus(com)
+        result = bus.databases
+        assert isinstance(result, SimulationBusDatabases)
+
+    def test_simulation_bus_databases_count(self):
+        com = MagicMock()
+        com.Count = 2
+        dbs = SimulationBusDatabases(com)
+        assert dbs.count == 2
+
+    def test_simulation_bus_database_properties(self):
+        com = MagicMock()
+        com.FullName = "C:/path/to/db.dbc"
+        com.Name = "db"
+        db = SimulationBusDatabase(com)
+        assert db.full_name == "C:/path/to/db.dbc"
+        assert db.name == "db"
+
+
+class TestGetSimulationBusNames:
+    def test_returns_all_names(self):
+        bus_specs = [
+            {"name": "CAN", "dbs": []},
+            {"name": "LIN", "dbs": []},
+        ]
+        bus_obj = _make_bus_obj(bus_specs)
+        result = bus_obj.get_simulation_bus_names()
+        assert result == ["CAN", "LIN"]
+
+    def test_includes_buses_with_empty_name(self):
+        bus_specs = [
+            {"name": "CAN", "dbs": []},
+            {"name": "", "dbs": []},
+            {"name": "ETH", "dbs": []},
+        ]
+        bus_obj = _make_bus_obj(bus_specs)
+        result = bus_obj.get_simulation_bus_names()
+        assert result == ["CAN", "", "ETH"]
+
+    def test_skips_buses_with_none_name(self):
+        from py_canoe.core.bus import Bus
+
+        buses_com = MagicMock()
+        buses_com.Count = 2
+
+        def buses_item(index):
+            bus_com = MagicMock()
+            bus_com.Name = None if index == 1 else "CAN"
+            bus_com.Databases.Count = 0
+            return bus_com
+
+        buses_com.Item.side_effect = buses_item
+        sim_buses = SimulationBuses.__new__(SimulationBuses)
+        sim_buses.com_object = buses_com
+
+        sim_setup = MagicMock(spec=SimulationSetup)
+        type(sim_setup).buses = PropertyMock(return_value=sim_buses)
+
+        app = MagicMock()
+        app.configuration.simulation_setup = sim_setup
+
+        bus_obj = Bus.__new__(Bus)
+        bus_obj.app = app
+        result = bus_obj.get_simulation_bus_names()
+        assert result == ["CAN"]
+
+    def test_returns_empty_list_when_no_buses(self):
+        bus_obj = _make_bus_obj([])
+        result = bus_obj.get_simulation_bus_names()
+        assert result == []
+
+    def test_raises_on_exception(self):
+        from py_canoe.core.bus import Bus
+
+        app = MagicMock()
+        type(app.configuration.simulation_setup).buses = PropertyMock(side_effect=Exception("COM error"))
+        bus_obj = Bus.__new__(Bus)
+        bus_obj.app = app
+        with pytest.raises(ConfigurationNotLoadedError):
+            bus_obj.get_simulation_bus_names()
+
+
+class TestGetSimulationDatabasePaths:
+    def test_returns_all_paths(self):
+        bus_specs = [
+            {"name": "CAN", "dbs": [
+                {"full_name": "C:/dbs/can.dbc", "name": "can"},
+                {"full_name": "C:/dbs/other.dbc", "name": "other"},
+            ]},
+            {"name": "LIN", "dbs": [
+                {"full_name": "C:/dbs/lin.ldf", "name": "lin"},
+            ]},
+        ]
+        bus_obj = _make_bus_obj(bus_specs)
+        result = bus_obj.get_simulation_database_paths()
+        assert "C:/dbs/can.dbc" in result
+        assert "C:/dbs/other.dbc" in result
+        assert "C:/dbs/lin.ldf" in result
+        assert len(result) == 3
+
+    def test_includes_empty_full_name(self):
+        bus_specs = [
+            {"name": "CAN", "dbs": [
+                {"full_name": "C:/dbs/can.dbc", "name": "can"},
+                {"full_name": "", "name": "empty"},
+            ]},
+        ]
+        bus_obj = _make_bus_obj(bus_specs)
+        result = bus_obj.get_simulation_database_paths()
+        assert result == ["C:/dbs/can.dbc", ""]
+
+    def test_skips_none_full_name(self):
+        from py_canoe.core.bus import Bus
+
+        buses_com = MagicMock()
+        buses_com.Count = 1
+
+        def buses_item(index):
+            bus_com = MagicMock()
+            bus_com.Name = "CAN"
+            dbs_com = MagicMock()
+            dbs_com.Count = 2
+
+            def dbs_item(j):
+                db_com = MagicMock()
+                db_com.FullName = None if j == 1 else "C:/dbs/can.dbc"
+                db_com.Name = "db"
+                return db_com
+
+            dbs_com.Item.side_effect = dbs_item
+            bus_com.Databases = dbs_com
+            return bus_com
+
+        buses_com.Item.side_effect = buses_item
+        sim_buses = SimulationBuses.__new__(SimulationBuses)
+        sim_buses.com_object = buses_com
+
+        sim_setup = MagicMock(spec=SimulationSetup)
+        type(sim_setup).buses = PropertyMock(return_value=sim_buses)
+
+        app = MagicMock()
+        app.configuration.simulation_setup = sim_setup
+
+        bus_obj = Bus.__new__(Bus)
+        bus_obj.app = app
+        result = bus_obj.get_simulation_database_paths()
+        assert result == ["C:/dbs/can.dbc"]
+
+    def test_returns_empty_list_when_no_databases(self):
+        bus_specs = [
+            {"name": "CAN", "dbs": []},
+            {"name": "LIN", "dbs": []},
+        ]
+        bus_obj = _make_bus_obj(bus_specs)
+        result = bus_obj.get_simulation_database_paths()
+        assert result == []
+
+    def test_raises_on_exception(self):
+        from py_canoe.core.bus import Bus
+
+        app = MagicMock()
+        type(app.configuration.simulation_setup).buses = PropertyMock(side_effect=Exception("COM error"))
+        bus_obj = Bus.__new__(Bus)
+        bus_obj.app = app
+        with pytest.raises(ConfigurationNotLoadedError):
+            bus_obj.get_simulation_database_paths()


### PR DESCRIPTION
## Summary                                                                                                                           
  Expose simulation setup buses and database paths via `Bus` class for programmatic access to CANoe simulation configuration.          
   
  ## Changes                                                                                                                           
  - Added `SimulationSetup` hierarchy classes (`SimulationSetup`, `SimulationBuses`, `SimulationBus`, `SimulationBusDatabases`,
  `SimulationBusDatabase`)
  - Added `simulation_setup` property to `Configuration` class
  - Added `get_simulation_bus_names()` and `get_simulation_database_paths()` methods to `Bus` class
  - Added `ConfigurationNotLoadedError` exception for error handling
  - Includes 17 unit tests and README examples

  ## Usage
  ```python
  canoe_inst = CANoe()
  canoe_inst.open(canoe_cfg=r'demo.cfg')
  bus_names = canoe_inst.application.bus.get_simulation_bus_names()
  db_paths = canoe_inst.application.bus.get_simulation_database_paths()

  Tests

  17 unit tests + integration tests passing