### PR TITLE
namespace and variable enumeration on System; fetch_all on Namespaces…

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,18 @@ sys_var_val = canoe_inst.get_system_variable_value('sys_demo::demo')
 canoe_inst.stop_measurement()
 ```
 
+### list system variable namespaces and variables
+
+```python
+from py_canoe import CANoe, wait
+
+canoe_inst = CANoe()
+canoe_inst.open(canoe_cfg=r'tests\demo_cfg\demo_dev.cfg')
+
+namespace_names = canoe_inst.application.system.get_all_namespace_names()
+variables = canoe_inst.application.system.get_all_variables_in_namespace('demo')
+```
+
 ### send diagnostic request, control tester present
 
 ```python

--- a/src/py_canoe/core/child_elements/namespaces.py
+++ b/src/py_canoe/core/child_elements/namespaces.py
@@ -12,6 +12,13 @@ class Namespaces:
     def item(self, index: int) -> 'Namespace':
         return Namespace(self.com_object.Item(index))
 
+    def fetch_all(self) -> list['Namespace']:
+        result = []
+        count = self.count
+        for i in range(1, count + 1):
+            result.append(self.item(i))
+        return result
+
     def add(self, name: str):
         return self.com_object.Add(name)
 

--- a/src/py_canoe/core/child_elements/variable.py
+++ b/src/py_canoe/core/child_elements/variable.py
@@ -112,7 +112,7 @@ class Variable:
     def set_value(self, value, timeout: Union[int, float]):
         status: bool = False
         self.com_object.Value = value
-        if self.variable_events:
+        if hasattr(self, 'variable_events') and self.variable_events:
             self.variable_events.VARIABLE_UPDATED = False
             status = DoEventsUntil(lambda: self.variable_events.VARIABLE_UPDATED, timeout, "Variable Update")
             if status:

--- a/src/py_canoe/core/child_elements/variables.py
+++ b/src/py_canoe/core/child_elements/variables.py
@@ -10,8 +10,15 @@ class Variables:
     def count(self):
         return self.com_object.Count
 
-    def item(self, index: int) -> 'Variable':
-        return Variable(self.com_object.Item(index))
+    def item(self, index: int, enable_events: bool = True) -> 'Variable':
+        return Variable(self.com_object.Item(index), enable_events=enable_events)
+
+    def fetch_all(self) -> list['Variable']:
+        result = []
+        count = self.count
+        for i in range(1, count + 1):
+            result.append(self.item(i, enable_events=False))
+        return result
 
     def add(self, name: str):
         return self.com_object.Add(name)

--- a/src/py_canoe/core/system.py
+++ b/src/py_canoe/core/system.py
@@ -2,8 +2,10 @@ from typing import Union
 
 from py_canoe.helpers.common import logger
 from py_canoe.core.child_elements.namespaces import Namespaces
+from py_canoe.core.child_elements.variables import Variables
 from py_canoe.core.child_elements.variables_files import VariablesFiles
 from py_canoe.core.child_elements.variable import Variable
+from py_canoe.exceptions import PyCanoeError, NamespaceNotFoundError
 
 
 class System:
@@ -149,6 +151,33 @@ class System:
         except Exception as e:
             logger.error(f"❌ Error getting system namespaces: {e}")
             return None
+
+    def get_all_namespace_names(self) -> list[str]:
+        try:
+            names = [ns.name for ns in self.namespaces.fetch_all()]
+        except Exception as e:
+            raise PyCanoeError(f"Failed to enumerate namespaces: {e}") from e
+        logger.info(f'📢 {len(names)} system variable namespace(s) found')
+        return names
+
+    def get_all_variables_in_namespace(self, namespace_name: str) -> list[dict]:
+        try:
+            ns_com = self.com_object.Namespaces(namespace_name)
+        except Exception as e:
+            raise NamespaceNotFoundError(f"Namespace '{namespace_name}' not found: {e}") from e
+        try:
+            variables_obj = Variables(ns_com.Variables)
+            result = []
+            for var in variables_obj.fetch_all():
+                result.append({
+                    "name": var.name,
+                    "value": var.get_value(),
+                    "full_name": var.full_name,
+                })
+            logger.info(f"📢 {len(result)} variable(s) found in '{namespace_name}'")
+            return result
+        except Exception as e:
+            raise PyCanoeError(f"Failed to enumerate variables in '{namespace_name}': {e}") from e
 
     def get_variables_files(self) -> dict[str, "VariablesFile"] | None:
         try:

--- a/tests/test_py_canoe.py
+++ b/tests/test_py_canoe.py
@@ -283,6 +283,21 @@ class TestStandalonePyCanoe:
         assert len(paths) > 0
         assert all(isinstance(p, str) for p in paths)
 
+    def test_get_all_namespace_names(self):
+        self.canoe_inst.open(canoe_cfg=self.canoe_cfg_dev, visible=True, auto_save=False, prompt_user=False)
+        names = self.canoe_inst.application.system.get_all_namespace_names()
+        assert isinstance(names, list)
+        assert 'demo' in names
+
+    def test_get_all_variables_in_namespace(self):
+        self.canoe_inst.open(canoe_cfg=self.canoe_cfg_dev, visible=True, auto_save=False, prompt_user=False)
+        variables = self.canoe_inst.application.system.get_all_variables_in_namespace('demo')
+        assert isinstance(variables, list)
+        assert len(variables) > 0
+        var_names = [v['name'] for v in variables]
+        assert 'sys_var2' in var_names
+        assert all('name' in v and 'value' in v and 'full_name' in v for v in variables)
+
     def test_logging(self):
         self.canoe_inst.open(canoe_cfg=self.canoe_cfg_online_setup)
         logging_blocks = self.canoe_inst.get_logging_blocks()

--- a/tests/test_unit_system_variable_enum.py
+++ b/tests/test_unit_system_variable_enum.py
@@ -1,0 +1,197 @@
+import pytest
+from unittest.mock import MagicMock, patch, PropertyMock
+from py_canoe.core.child_elements.namespaces import Namespaces
+from py_canoe.core.child_elements.variables import Variables
+from py_canoe.core.system import System
+from py_canoe.exceptions import PyCanoeError, NamespaceNotFoundError
+
+
+def _make_namespaces(names):
+    com = MagicMock()
+    com.Count = len(names)
+
+    def item_side_effect(index):
+        ns = MagicMock()
+        ns.Name = names[index - 1]
+        return ns
+
+    com.Item.side_effect = item_side_effect
+    ns_obj = Namespaces.__new__(Namespaces)
+    ns_obj.com_object = com
+    return ns_obj
+
+
+def _make_variables(entries):
+    com = MagicMock()
+    com.Count = len(entries)
+
+    def item_side_effect(index):
+        e = entries[index - 1]
+        var_com = MagicMock()
+        var_com.Name = e["name"]
+        var_com.Value = e["value"]
+        var_com.FullName = e["full_name"]
+        return var_com
+
+    com.Item.side_effect = item_side_effect
+    var_obj = Variables.__new__(Variables)
+    var_obj.com_object = com
+    return var_obj
+
+
+class TestNamespacesFetchAll:
+    def test_returns_all_namespaces(self):
+        ns_obj = _make_namespaces(["demo", "TestControl"])
+        result = ns_obj.fetch_all()
+        assert len(result) == 2
+        assert result[0].name == "demo"
+        assert result[1].name == "TestControl"
+
+    def test_returns_empty_list_when_none(self):
+        ns_obj = _make_namespaces([])
+        result = ns_obj.fetch_all()
+        assert result == []
+
+    def test_raises_on_exception_mid_iteration(self):
+        com = MagicMock()
+        com.Count = 3
+        call_count = [0]
+
+        def item_side_effect(index):
+            call_count[0] += 1
+            if call_count[0] == 2:
+                raise Exception("COM error on item 2")
+            ns = MagicMock()
+            ns.Name = f"ns_{index}"
+            return ns
+
+        com.Item.side_effect = item_side_effect
+        ns_obj = Namespaces.__new__(Namespaces)
+        ns_obj.com_object = com
+        with pytest.raises(Exception):
+            ns_obj.fetch_all()
+
+    def test_raises_on_count_exception(self):
+        com = MagicMock()
+        type(com).Count = PropertyMock(side_effect=Exception("COM error"))
+        ns_obj = Namespaces.__new__(Namespaces)
+        ns_obj.com_object = com
+        with pytest.raises(Exception):
+            ns_obj.fetch_all()
+
+
+class TestVariablesFetchAll:
+    def test_returns_all_variables(self):
+        entries = [
+            {"name": "speed", "value": 100, "full_name": "demo::speed"},
+            {"name": "level", "value": 5,   "full_name": "demo::level"},
+        ]
+        var_obj = _make_variables(entries)
+        with patch("py_canoe.core.child_elements.variable.win32com.client.Dispatch", side_effect=lambda x: x):
+            result = var_obj.fetch_all()
+        assert len(result) == 2
+        assert result[0].name == "speed"
+        assert result[1].name == "level"
+
+    def test_returns_empty_list_when_none(self):
+        var_obj = _make_variables([])
+        result = var_obj.fetch_all()
+        assert result == []
+
+    def test_raises_on_count_exception(self):
+        com = MagicMock()
+        type(com).Count = PropertyMock(side_effect=Exception("COM error"))
+        var_obj = Variables.__new__(Variables)
+        var_obj.com_object = com
+        with pytest.raises(Exception):
+            var_obj.fetch_all()
+
+
+class TestSystemGetAllNamespaceNames:
+    def _make_system(self, names):
+        app = MagicMock()
+        com = MagicMock()
+        com.Count = len(names)
+
+        def item_side_effect(index):
+            ns = MagicMock()
+            ns.Name = names[index - 1]
+            return ns
+
+        com.Item.side_effect = item_side_effect
+        app.com_object.System.Namespaces = com
+        sys_obj = System.__new__(System)
+        sys_obj.com_object = app.com_object.System
+        return sys_obj
+
+    def test_returns_names(self):
+        sys_obj = self._make_system(["demo", "TestControl"])
+        result = sys_obj.get_all_namespace_names()
+        assert "demo" in result
+        assert "TestControl" in result
+
+    def test_raises_on_exception(self):
+        sys_obj = System.__new__(System)
+        com = MagicMock()
+        type(com).Namespaces = PropertyMock(side_effect=Exception("COM error"))
+        sys_obj.com_object = com
+        with pytest.raises(PyCanoeError):
+            sys_obj.get_all_namespace_names()
+
+
+class TestSystemGetAllVariablesInNamespace:
+    def _make_system_with_namespace(self, var_entries):
+        sys_obj = System.__new__(System)
+        com = MagicMock()
+        ns_com = MagicMock()
+        vars_com = MagicMock()
+        vars_com.Count = len(var_entries)
+
+        def item_side_effect(index):
+            e = var_entries[index - 1]
+            var_com = MagicMock()
+            var_com.Name = e["name"]
+            var_com.Value = e["value"]
+            var_com.FullName = e["full_name"]
+            return var_com
+
+        vars_com.Item.side_effect = item_side_effect
+        ns_com.Variables = vars_com
+        com.Namespaces.return_value = ns_com
+        sys_obj.com_object = com
+        return sys_obj
+
+    def test_returns_correct_dict_keys(self):
+        entries = [{"name": "speed", "value": 10, "full_name": "demo::speed"}]
+        sys_obj = self._make_system_with_namespace(entries)
+        with patch("py_canoe.core.child_elements.variable.win32com.client.Dispatch", side_effect=lambda x: x):
+            result = sys_obj.get_all_variables_in_namespace("demo")
+        assert len(result) == 1
+        assert result[0]["name"] == "speed"
+        assert result[0]["value"] == 10
+        assert result[0]["full_name"] == "demo::speed"
+
+    def test_raises_for_unknown_namespace(self):
+        sys_obj = System.__new__(System)
+        com = MagicMock()
+        com.Namespaces.side_effect = Exception("namespace not found")
+        sys_obj.com_object = com
+        with pytest.raises(NamespaceNotFoundError):
+            sys_obj.get_all_variables_in_namespace("nonexistent")
+
+    def test_returns_empty_list_when_no_variables(self):
+        sys_obj = self._make_system_with_namespace([])
+        result = sys_obj.get_all_variables_in_namespace("empty_ns")
+        assert result == []
+
+    def test_raises_pycanoe_error_on_fetch_failure(self):
+        sys_obj = System.__new__(System)
+        com = MagicMock()
+        ns_com = MagicMock()
+        vars_com = MagicMock()
+        type(vars_com).Count = PropertyMock(side_effect=Exception("COM error during fetch"))
+        ns_com.Variables = vars_com
+        com.Namespaces.return_value = ns_com
+        sys_obj.com_object = com
+        with pytest.raises(PyCanoeError):
+            sys_obj.get_all_variables_in_namespace("demo")


### PR DESCRIPTION
 ## Summary                                                                                                                           
  Add system variable namespace and variable enumeration methods for discovering all system variables in a CANoe configuration.
                                                                                                                                       
  ## Changes                                                
  - Added `fetch_all()` method to `Namespaces` and `Variables` classes with count snapshot for thread safety
  - Added `get_all_namespace_names()` and `get_all_variables_in_namespace()` to `System` class
  - Fixed `Variable.set_value()` AttributeError when `enable_events=False` (added hasattr guard)
  - Added `PyCanoeError` and `NamespaceNotFoundError` exception classes
  - Includes 13 unit tests and README examples

  ## Usage
  ```python
  canoe_inst = CANoe()
  canoe_inst.open(canoe_cfg=r'demo.cfg')
  namespaces = canoe_inst.application.system.get_all_namespace_names()
  variables = canoe_inst.application.system.get_all_variables_in_namespace('demo')
  # Returns: [{'name': 'sys_var2', 'value': 0, 'full_name': 'demo::sys_var2'}, ...]

  Tests

  13 unit tests + integration tests passing