### PR TITLE
compile_and_verify_with_result and check_compilation_state on Configu…

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,18 @@ canoe_inst.control_replay_block(block_name='DemoReplayBlock', start_stop=False)
 canoe_inst.stop_measurement()
 ```
 
+### compile CAPL nodes and get detailed error output
+
+```python
+from py_canoe import CANoe, wait
+
+canoe_inst = CANoe()
+canoe_inst.open(canoe_cfg=r'tests\demo_cfg\demo_dev.cfg')
+
+result = canoe_inst.application.configuration.compile_and_verify_with_result()
+state = canoe_inst.application.configuration.run_compilation()
+```
+
 ### compile CAPL nodes and call capl function
 
 ```python

--- a/src/py_canoe/core/configuration.py
+++ b/src/py_canoe/core/configuration.py
@@ -161,8 +161,32 @@ class Configuration:
 
     # VTSystem
 
-    def compile_and_verify(self) -> bool:
+    def compile_and_verify(self) -> None:
         self.com_object.CompileAndVerify()
+        logger.info("CAPL compilation completed successfully.")
+
+    def compile_and_verify_with_result(self) -> dict[str, object]:
+        result = self._compile_and_verify_internal()
+        if result["success"]:
+            logger.info('CAPL compilation succeeded')
+        else:
+            logger.warning(f'CAPL compilation failed: {result["error"]}')
+        return result
+
+    def run_compilation(self) -> bool:
+        result = self._compile_and_verify_internal()
+        if result["success"]:
+            logger.info('CAPL compilation passed')
+        else:
+            logger.warning(f'CAPL compilation failed: {result["error"]}')
+        return result["success"]
+
+    def _compile_and_verify_internal(self) -> dict[str, object]:
+        try:
+            self.com_object.CompileAndVerify()
+            return {"success": True, "error": None}
+        except Exception as e:
+            return {"success": False, "error": str(e)}
 
     def save(self) -> bool:
         try:

--- a/tests/test_py_canoe.py
+++ b/tests/test_py_canoe.py
@@ -248,6 +248,18 @@ class TestStandalonePyCanoe:
         assert self.canoe_inst.remove_database(fr"{self.file_path}\demo_cfg\DBs\sample_databases\XCP.dbc", 1)
         assert self.canoe_inst.save_configuration()
 
+    def test_compile_and_verify_with_result(self):
+        self.canoe_inst.open(canoe_cfg=self.canoe_cfg_dev, visible=True, auto_save=False, prompt_user=False)
+        result = self.canoe_inst.application.configuration.compile_and_verify_with_result()
+        assert isinstance(result, dict)
+        assert "success" in result
+        assert "error" in result
+
+    def test_run_compilation(self):
+        self.canoe_inst.open(canoe_cfg=self.canoe_cfg_dev, visible=True, auto_save=False, prompt_user=False)
+        state = self.canoe_inst.application.configuration.run_compilation()
+        assert isinstance(state, bool)
+
     def test_logging(self):
         self.canoe_inst.open(canoe_cfg=self.canoe_cfg_online_setup)
         logging_blocks = self.canoe_inst.get_logging_blocks()

--- a/tests/test_unit_compile_verify.py
+++ b/tests/test_unit_compile_verify.py
@@ -1,0 +1,65 @@
+from unittest.mock import MagicMock
+from py_canoe.core.configuration import Configuration
+
+
+def _make_configuration(compile_raises=False):
+    cfg = Configuration.__new__(Configuration)
+    com = MagicMock()
+    if compile_raises:
+        com.CompileAndVerify.side_effect = Exception("COM error")
+    cfg.com_object = com
+    return cfg
+
+
+class TestCompileAndVerifyInternal:
+    def test_returns_success_dict_on_success(self):
+        cfg = _make_configuration()
+        result = cfg._compile_and_verify_internal()
+        assert result == {"success": True, "error": None}
+
+    def test_returns_failure_dict_on_exception(self):
+        cfg = _make_configuration(compile_raises=True)
+        result = cfg._compile_and_verify_internal()
+        assert result["success"] is False
+        assert "COM error" in result["error"]
+
+    def test_calls_com_exactly_once(self):
+        cfg = _make_configuration()
+        cfg._compile_and_verify_internal()
+        cfg.com_object.CompileAndVerify.assert_called_once()
+
+
+class TestCompileAndVerifyWithResult:
+    def test_delegates_to_internal(self):
+        cfg = _make_configuration()
+        result = cfg.compile_and_verify_with_result()
+        cfg.com_object.CompileAndVerify.assert_called_once()
+        assert result["success"] is True
+        assert result["error"] is None
+
+    def test_returns_failure_dict_on_exception(self):
+        cfg = _make_configuration(compile_raises=True)
+        result = cfg.compile_and_verify_with_result()
+        assert result["success"] is False
+        assert "COM error" in result["error"]
+
+    def test_return_dict_has_correct_keys(self):
+        cfg = _make_configuration()
+        result = cfg.compile_and_verify_with_result()
+        assert set(result.keys()) == {"success", "error"}
+
+
+class TestRunCompilation:
+    def test_delegates_to_internal(self):
+        cfg = _make_configuration()
+        state = cfg.run_compilation()
+        cfg.com_object.CompileAndVerify.assert_called_once()
+        assert state is True
+
+    def test_returns_false_on_exception(self):
+        cfg = _make_configuration(compile_raises=True)
+        assert cfg.run_compilation() is False
+
+    def test_return_type_is_bool(self):
+        cfg = _make_configuration()
+        assert isinstance(cfg.run_compilation(), bool)


### PR DESCRIPTION
 ## Summary                                                                                                                           
  Add CAPL compilation verification methods with detailed result information to `Configuration` class.                                 
   
  ## Changes                                                                                                                           
  - Added `compile_and_verify_with_result()` method returning dict with success status and error details
  - Added `run_compilation()` method returning boolean compilation status
  - Added internal `_compile_and_verify_internal()` helper to avoid code duplication
  - Includes 9 unit tests and README examples

  ## Usage
  ```python
  canoe_inst = CANoe()
  canoe_inst.open(canoe_cfg=r'demo.cfg')

  # Get detailed result
  result = canoe_inst.application.configuration.compile_and_verify_with_result()
  # Returns: {"success": True, "error": None}

  # Get boolean status
  state = canoe_inst.application.configuration.run_compilation()
  # Returns: True

  Tests

  9 unit tests + integration tests passing