### PR TITLE
add get_compilation_result and run_compilation methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,24 @@ canoe_inst.control_replay_block(block_name='DemoReplayBlock', start_stop=False)
 canoe_inst.stop_measurement()
 ```
 
+### compile CAPL nodes with success check
+
+```python
+from py_canoe import CANoe, wait
+
+canoe_inst = CANoe()
+canoe_inst.open(canoe_cfg=r'tests\demo_cfg\demo_dev.cfg')
+
+# Simple bool check
+if canoe_inst.application.configuration.run_compilation():
+    print("Compilation OK")
+
+# Get detailed error information
+result = canoe_inst.application.configuration.get_compilation_result()
+if not result["success"]:
+    print(f"Compilation failed: {result['error']}")
+```
+
 ### compile CAPL nodes and call capl function
 
 ```python

--- a/src/py_canoe/core/configuration.py
+++ b/src/py_canoe/core/configuration.py
@@ -161,8 +161,61 @@ class Configuration:
 
     # VTSystem
 
-    def compile_and_verify(self) -> bool:
+    def compile_and_verify(self) -> None:
         self.com_object.CompileAndVerify()
+        logger.info("CAPL compilation completed successfully.")
+
+    def get_compilation_result(self) -> dict[str, object]:
+        """Get CAPL compilation result with error details.
+
+        Compiles all CAPL code in the current configuration and returns
+        detailed result including success status and error information.
+
+        Returns:
+            dict: Dictionary with keys:
+                - "success" (bool): True if compilation succeeded, False otherwise
+                - "error" (str | None): Error message if compilation failed, None on success
+
+        Example:
+            >>> result = config.get_compilation_result()
+            >>> if result["success"]:
+            ...     print("Compilation OK")
+            ... else:
+            ...     print(f"Compilation failed: {result['error']}")
+        """
+        result = self._compile_and_verify_internal()
+        if result["success"]:
+            logger.info('CAPL compilation succeeded')
+        else:
+            logger.warning(f'CAPL compilation failed: {result["error"]}')
+        return result
+
+    def run_compilation(self) -> bool:
+        """Run CAPL compilation and return success status.
+
+        Compiles all CAPL code in the current configuration.
+        Use get_compilation_result() if you need error details.
+
+        Returns:
+            bool: True if compilation succeeded, False otherwise
+
+        Example:
+            >>> if config.run_compilation():
+            ...     print("Compilation OK")
+        """
+        result = self._compile_and_verify_internal()
+        if result["success"]:
+            logger.info('CAPL compilation passed')
+        else:
+            logger.warning(f'CAPL compilation failed: {result["error"]}')
+        return result["success"]
+
+    def _compile_and_verify_internal(self) -> dict[str, object]:
+        try:
+            self.com_object.CompileAndVerify()
+            return {"success": True, "error": None}
+        except Exception as e:
+            return {"success": False, "error": str(e)}
 
     def save(self) -> bool:
         try:

--- a/tests/test_py_canoe.py
+++ b/tests/test_py_canoe.py
@@ -248,6 +248,20 @@ class TestStandalonePyCanoe:
         assert self.canoe_inst.remove_database(fr"{self.file_path}\demo_cfg\DBs\sample_databases\XCP.dbc", 1)
         assert self.canoe_inst.save_configuration()
 
+    def test_get_compilation_result(self):
+        self.canoe_inst.open(canoe_cfg=self.canoe_cfg_dev, visible=True, auto_save=False, prompt_user=False)
+        result = self.canoe_inst.application.configuration.get_compilation_result()
+        assert isinstance(result, dict)
+        assert "success" in result
+        assert "error" in result
+        assert result["success"] is True
+
+    def test_run_compilation(self):
+        self.canoe_inst.open(canoe_cfg=self.canoe_cfg_dev, visible=True, auto_save=False, prompt_user=False)
+        result = self.canoe_inst.application.configuration.run_compilation()
+        assert isinstance(result, bool)
+        assert result is True
+
     def test_logging(self):
         self.canoe_inst.open(canoe_cfg=self.canoe_cfg_online_setup)
         logging_blocks = self.canoe_inst.get_logging_blocks()

--- a/tests/test_unit_compile_verify.py
+++ b/tests/test_unit_compile_verify.py
@@ -1,0 +1,72 @@
+from unittest.mock import MagicMock
+from py_canoe.core.configuration import Configuration
+
+
+def _make_configuration(compile_raises=False):
+    cfg = Configuration.__new__(Configuration)
+    com = MagicMock()
+    if compile_raises:
+        com.CompileAndVerify.side_effect = Exception("COM error")
+    cfg.com_object = com
+    return cfg
+
+
+class TestCompileAndVerifyInternal:
+    def test_returns_success_dict_on_success(self):
+        cfg = _make_configuration()
+        result = cfg._compile_and_verify_internal()
+        assert result == {"success": True, "error": None}
+
+    def test_returns_failure_dict_on_exception(self):
+        cfg = _make_configuration(compile_raises=True)
+        result = cfg._compile_and_verify_internal()
+        assert result["success"] is False
+        assert "COM error" in result["error"]
+
+    def test_calls_com_exactly_once(self):
+        cfg = _make_configuration()
+        cfg._compile_and_verify_internal()
+        cfg.com_object.CompileAndVerify.assert_called_once()
+
+
+class TestGetCompilationResult:
+    def test_delegates_to_internal(self):
+        cfg = _make_configuration()
+        result = cfg.get_compilation_result()
+        cfg.com_object.CompileAndVerify.assert_called_once()
+        assert result["success"] is True
+        assert result["error"] is None
+
+    def test_returns_failure_dict_on_exception(self):
+        cfg = _make_configuration(compile_raises=True)
+        result = cfg.get_compilation_result()
+        assert result["success"] is False
+        assert "COM error" in result["error"]
+
+    def test_return_dict_has_correct_keys(self):
+        cfg = _make_configuration()
+        result = cfg.get_compilation_result()
+        assert set(result.keys()) == {"success", "error"}
+
+    def test_return_type_is_dict(self):
+        cfg = _make_configuration()
+        result = cfg.get_compilation_result()
+        assert isinstance(result, dict)
+
+
+class TestRunCompilation:
+    def test_returns_true_on_success(self):
+        cfg = _make_configuration()
+        result = cfg.run_compilation()
+        cfg.com_object.CompileAndVerify.assert_called_once()
+        assert result is True
+
+    def test_returns_false_on_exception(self):
+        cfg = _make_configuration(compile_raises=True)
+        result = cfg.run_compilation()
+        assert result is False
+
+    def test_return_type_is_bool(self):
+        cfg = _make_configuration()
+        result = cfg.run_compilation()
+        assert isinstance(result, bool)


### PR DESCRIPTION
## Summary
- Add `run_compilation() -> bool` for simple pass/fail checks
- Add `get_compilation_result() -> dict` for detailed error information
- Fix `compile_and_verify()` return type annotation: `bool` → `None`

## Breaking Change
`compile_and_verify()` annotation changed from `-> bool` to `-> None`. 
Note: The method already returned `None` implicitly — this corrects the misleading type hint.

## Test plan
- 10 unit tests added
- Integration tests included