### PR TITLE
fix missing Optional import in canoe.py

### DIFF
--- a/src/py_canoe/canoe.py
+++ b/src/py_canoe/canoe.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Iterable
+from typing import TYPE_CHECKING, Iterable, Optional
 if TYPE_CHECKING:
     from py_canoe.core.child_elements.measurement_setup import Logging, ExporterSymbol, Message
     from py_canoe.core.child_elements.test_configurations import TestConfiguration


### PR DESCRIPTION
  Fix missing Optional import causing package import failure
                                                                                                                                                                                               
  The canoe.py module uses Optional[int] type hint in the   
  profile_signal_value method signature but did not import Optional
  from the typing module. This caused a NameError when attempting to
  import py_canoe, making the entire package unusable. Added Optional
  to the existing typing import statement to resolve the issue.