### PR TITLE
Feature/pytest integration skip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,12 @@ documentation = "https://chaitu-ycr.github.io/py-canoe/"
 [tool.uv]
 package = true
 
+[tool.pytest.ini_options]
+markers = [
+    "integration: Integration tests requiring CANoe COM interface",
+    "unit: Unit tests with mocks (default)",
+]
+
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,18 +1,24 @@
+import sys
 import pytest
-import pythoncom
 
 
 def is_canoe_available() -> bool:
     """Check if CANoe COM interface is available."""
+    if sys.platform != "win32":
+        return False
+
     try:
-        pythoncom.CoInitialize()
+        import pythoncom
         import win32com.client
+
+        pythoncom.CoInitialize()
         canoe_app = win32com.client.Dispatch("CANoe.Application")
         del canoe_app
         pythoncom.CoUninitialize()
         return True
     except Exception:
         try:
+            import pythoncom
             pythoncom.CoUninitialize()
         except Exception:
             pass
@@ -21,5 +27,5 @@ def is_canoe_available() -> bool:
 
 skip_if_no_canoe = pytest.mark.skipif(
     not is_canoe_available(),
-    reason="CANoe COM interface not available"
+    reason="CANoe requires Windows and COM interface"
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,25 @@
+import pytest
+import pythoncom
+
+
+def is_canoe_available() -> bool:
+    """Check if CANoe COM interface is available."""
+    try:
+        pythoncom.CoInitialize()
+        import win32com.client
+        canoe_app = win32com.client.Dispatch("CANoe.Application")
+        del canoe_app
+        pythoncom.CoUninitialize()
+        return True
+    except Exception:
+        try:
+            pythoncom.CoUninitialize()
+        except Exception:
+            pass
+        return False
+
+
+skip_if_no_canoe = pytest.mark.skipif(
+    not is_canoe_available(),
+    reason="CANoe COM interface not available"
+)

--- a/tests/test_py_canoe.py
+++ b/tests/test_py_canoe.py
@@ -1,8 +1,12 @@
 import os
+import pytest
 from py_canoe import CANoe, wait
 from py_canoe.helpers.common import logger
+from tests.conftest import skip_if_no_canoe
 
 
+@pytest.mark.integration
+@skip_if_no_canoe
 class TestStandalonePyCanoe:
     @classmethod
     def setup_class(cls):


### PR DESCRIPTION
 Add conditional skip for integration tests requiring CANoe
                                                                                                                                                                                               
  Problem:
  27 integration tests in test_py_canoe.py require CANoe COM interface.                                                                                                                        
  Without CANoe: pywintypes.com_error causes test failures on machines without CANoe installation.

  Solution:
  - tests/conftest.py: is_canoe_available() checks COM interface via
    win32com.client.Dispatch("CANoe.Application")
  - tests/test_py_canoe.py: Added @pytest.mark.integration and
    @skip_if_no_canoe to TestStandalonePyCanoe (27 tests)
  - pyproject.toml: Defined integration/unit markers
  Result: Integration tests skip with "CANoe COM interface not available"
  instead of failing when CANoe is absent.