### PR TITLE
Add option to disable events for get_system_variable_value

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "py-canoe"
-version = "26.2.4"
+version = "26.2.5"
 description = "Python 🐍 Package for accessing Vector CANoe 🛶 Tool via COM Interface"
 license = { file = "LICENSE" }
 readme = "README.md"

--- a/src/py_canoe/canoe.py
+++ b/src/py_canoe/canoe.py
@@ -877,7 +877,7 @@ class CANoe:
         """
         return self.application.system.add_variable(sys_var_name, value, read_only)
 
-    def get_system_variable_value(self, sys_var_name: str, return_symbolic_name: bool = False, return_timestamp: bool = False) -> Union[int, float, str, None, tuple]:
+    def get_system_variable_value(self, sys_var_name: str, return_symbolic_name: bool = False, return_timestamp: bool = False, enable_events: bool = True) -> Union[int, float, str, None, tuple]:
         """
         Gets the value of a system variable.
 
@@ -885,11 +885,12 @@ class CANoe:
             sys_var_name (str): The name of the system variable.
             return_symbolic_name (bool): Whether to return the symbolic name.
             return_timestamp (bool): Whether to return the timestamp in timezone utc along with the signal value. Defaults to False.
+            enable_events (bool): Whether to enable COM events on the Variable object. Defaults to True.
 
         Returns:
             Union[int, float, str, None, tuple]: The value of the system variable or None if not found. If return_timestamp is True, returns a tuple of (value, timestamp).
         """
-        variable_value = self.application.system.get_variable_value(sys_var_name, return_symbolic_name)
+        variable_value = self.application.system.get_variable_value(sys_var_name, return_symbolic_name, enable_events)
         if return_timestamp:
             return variable_value, datetime.now(timezone.utc).timestamp()
         return variable_value

--- a/src/py_canoe/core/system.py
+++ b/src/py_canoe/core/system.py
@@ -74,7 +74,7 @@ class System:
             logger.error(f"Error removing System Variable '{sys_var_name}': {e}")
             return False
 
-    def get_variable_value(self, sys_var_name: str, return_symbolic_name=False) -> Union[int, float, str, None]:
+    def get_variable_value(self, sys_var_name: str, return_symbolic_name=False, enable_events: bool = True) -> Union[int, float, str, None]:
         try:
             parts = sys_var_name.split('::')
             if len(parts) < 2:
@@ -83,7 +83,7 @@ class System:
             namespace = '::'.join(parts[:-1])
             variable_name = parts[-1]
             namespace_obj = self.com_object.Namespaces(namespace)
-            variable_obj = Variable(namespace_obj.Variables(variable_name))
+            variable_obj = Variable(namespace_obj.Variables(variable_name), enable_events)
             value = variable_obj.get_value()
             if return_symbolic_name:
                 symbolic_value = variable_obj.get_symbolic_value_name(value)


### PR DESCRIPTION
When polling in a loop, enable_events=True cause a COM sink overflow and CANoe becomes unresponsive.