### PR TITLE
Feature/com message filter

### DIFF
--- a/src/py_canoe/core/application.py
+++ b/src/py_canoe/core/application.py
@@ -9,6 +9,7 @@ from py_canoe.core.capl import Capl
 from py_canoe.core.configuration import Configuration
 from py_canoe.core.environment import Environment
 from py_canoe.core.measurement import Measurement
+from py_canoe.core.message_filter import COMRetryMessageFilter
 from py_canoe.core.networks import Networks
 from py_canoe.core.system import System
 from py_canoe.core.ui import Ui
@@ -31,6 +32,14 @@ class ApplicationEvents:
 
 
 class Application:
+    """Main interface to CANoe via COM automation.
+
+    The Application class automatically registers an IMessageFilter that suppresses
+    'Server Busy' dialogs when CANoe is temporarily unable to process COM calls
+    (e.g., during report generation after measurement stop). Rejected calls are
+    retried automatically with exponential backoff up to 60 seconds.
+    """
+
     def __init__(self, enable_events: bool = True) -> None:
         self._enable_events = enable_events
         self.bus_types = {'CAN': 1, 'J1939': 2, 'TTP': 4, 'LIN': 5, 'MOST': 6, 'Kline': 14}
@@ -46,6 +55,10 @@ class Application:
         self.version: Version = None
         self.capl_function_objects = object()
         self.user_capl_functions = tuple()
+        # Register IMessageFilter to suppress "Server Busy" dialogs and auto-retry
+        # rejected COM calls. The filter stays active for the Application's lifetime.
+        self._message_filter = COMRetryMessageFilter()
+        self._message_filter.register()
 
     @property
     def full_name(self) -> str:

--- a/src/py_canoe/core/measurement.py
+++ b/src/py_canoe/core/measurement.py
@@ -129,31 +129,15 @@ class Measurement:
             return True
         logger.info("stop_ex: calling Stop()")
         self.measurement_events.STOP = False
-        retry_count = 0
-        deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
-            if not self.com_object.Running:
-                elapsed = round(time.monotonic() - t0, 2)
-                logger.info(f"stop_ex: measurement stopped naturally after {elapsed}s (retries={retry_count})")
-                return True
-            try:
-                self.com_object.Stop()
-                elapsed = round(time.monotonic() - t0, 2)
-                logger.info(f"stop_ex: Stop() accepted after {elapsed}s (retries={retry_count})")
-                break
-            except Exception as e:
-                err_str = str(e)
-                if "busy" in err_str.lower() or "-2147418113" in err_str or "0x8000ffff" in err_str.lower():
-                    retry_count += 1
-                    elapsed = round(time.monotonic() - t0, 2)
-                    logger.warning(f"stop_ex: CANoe busy at {elapsed}s (retry #{retry_count}) — waiting 5s: {e}")
-                    time.sleep(5.0)
-                    continue
-                logger.error(f"stop_ex: unexpected error: {e}")
-                return False
-        else:
+        try:
+            # IMessageFilter (registered in Application.__init__) handles busy-retry
+            # automatically — no manual retry loop needed here.
+            self.com_object.Stop()
             elapsed = round(time.monotonic() - t0, 2)
-            logger.error(f"stop_ex: timeout after {elapsed}s — Stop() never accepted (retries={retry_count})")
+            logger.info(f"stop_ex: Stop() accepted after {elapsed}s")
+        except Exception as e:
+            elapsed = round(time.monotonic() - t0, 2)
+            logger.error(f"stop_ex: Stop() failed after {elapsed}s: {e}")
             return False
         if self._enable_events:
             status = DoEventsUntil(lambda: self.measurement_events.STOP, timeout, "CANoe Measurement Stop")

--- a/src/py_canoe/core/message_filter.py
+++ b/src/py_canoe/core/message_filter.py
@@ -1,0 +1,187 @@
+"""COM IMessageFilter to suppress 'Server Busy' dialogs.
+
+When CANoe is busy (e.g., generating reports after measurement stop), COM calls
+from Python may trigger a Windows dialog: "This action cannot be completed because
+the other program is busy". This module provides an IMessageFilter implementation
+that automatically retries rejected calls and suppresses the dialog.
+
+The filter is registered per STA thread via CoRegisterMessageFilter. pythoncom
+does not expose this API, so we use ctypes to build a proper COM vtable manually.
+"""
+
+import ctypes
+import ctypes.wintypes
+import logging
+
+_logger = logging.getLogger("PY_CANOE")
+
+# Load ole32.dll for CoRegisterMessageFilter
+_ole32 = ctypes.windll.ole32
+_CoRegisterMessageFilter = _ole32.CoRegisterMessageFilter
+_CoRegisterMessageFilter.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p)]
+_CoRegisterMessageFilter.restype = ctypes.HRESULT
+
+# IMessageFilter vtable callback signatures
+_HANDLEINCOMINGCALL = ctypes.WINFUNCTYPE(
+    ctypes.c_int,  # return: DWORD (SERVERCALL_*)
+    ctypes.c_void_p,  # this
+    ctypes.wintypes.DWORD,  # dwCallType
+    ctypes.c_void_p,  # htaskCaller
+    ctypes.wintypes.DWORD,  # dwTickCount
+    ctypes.c_void_p,  # lpInterfaceInfo
+)
+_RETRYREJECTEDCALL = ctypes.WINFUNCTYPE(
+    ctypes.c_int,  # return: DWORD (milliseconds to wait, or -1 to cancel)
+    ctypes.c_void_p,  # this
+    ctypes.c_void_p,  # htaskCallee
+    ctypes.wintypes.DWORD,  # dwTickCount
+    ctypes.wintypes.DWORD,  # dwRejectType
+)
+_MESSAGEPENDING = ctypes.WINFUNCTYPE(
+    ctypes.c_int,  # return: DWORD (PENDINGMSG_*)
+    ctypes.c_void_p,  # this
+    ctypes.c_void_p,  # htaskCallee
+    ctypes.wintypes.DWORD,  # dwTickCount
+    ctypes.wintypes.DWORD,  # dwPendingType
+)
+
+
+class _IMessageFilterVtbl(ctypes.Structure):
+    """COM vtable layout for IMessageFilter."""
+
+    _fields_ = [
+        ("QueryInterface", ctypes.c_void_p),
+        ("AddRef", ctypes.c_void_p),
+        ("Release", ctypes.c_void_p),
+        ("HandleInComingCall", ctypes.c_void_p),
+        ("RetryRejectedCall", ctypes.c_void_p),
+        ("MessagePending", ctypes.c_void_p),
+    ]
+
+
+class _IMessageFilterImpl(ctypes.Structure):
+    """COM object layout: pointer to vtable."""
+
+    _fields_ = [("lpVtbl", ctypes.POINTER(_IMessageFilterVtbl))]
+
+
+class COMRetryMessageFilter:
+    """IMessageFilter that retries rejected COM calls and suppresses 'Server Busy' dialogs.
+
+    Usage:
+        filter = COMRetryMessageFilter()
+        filter.register()
+        # ... COM calls are now protected ...
+        # filter.unregister()  # optional, usually kept active for app lifetime
+
+    The filter uses exponential backoff for retries:
+    - 0-1s: retry every 100ms
+    - 1-5s: retry every 500ms
+    - 5-30s: retry every 2s
+    - 30-60s: retry every 5s
+    - >60s: give up (cancel call)
+    """
+
+    _CANCEL_CALL = 0xFFFFFFFF  # -1 as DWORD
+
+    def __init__(self) -> None:
+        self._last_log_time = 0
+        self._rejection_count = 0
+        self._old_filter = ctypes.c_void_p()
+        self._registered = False
+
+        # IUnknown stubs — COM does not call these for message filters
+        _qi_type = ctypes.WINFUNCTYPE(
+            ctypes.HRESULT, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p
+        )
+        _ref_type = ctypes.WINFUNCTYPE(ctypes.c_ulong, ctypes.c_void_p)
+        self._qi = _qi_type(lambda this, riid, ppv: 0x80004002)  # E_NOINTERFACE
+        self._addref = _ref_type(lambda this: 1)
+        self._release = _ref_type(lambda this: 1)
+
+        # IMessageFilter callbacks — prevent GC by storing on self
+        self._cb_handle = _HANDLEINCOMINGCALL(self._on_handle_incoming)
+        self._cb_retry = _RETRYREJECTEDCALL(self._on_retry_rejected)
+        self._cb_pending = _MESSAGEPENDING(self._on_message_pending)
+
+        self._vtbl = _IMessageFilterVtbl(
+            QueryInterface=ctypes.cast(self._qi, ctypes.c_void_p).value,
+            AddRef=ctypes.cast(self._addref, ctypes.c_void_p).value,
+            Release=ctypes.cast(self._release, ctypes.c_void_p).value,
+            HandleInComingCall=ctypes.cast(self._cb_handle, ctypes.c_void_p).value,
+            RetryRejectedCall=ctypes.cast(self._cb_retry, ctypes.c_void_p).value,
+            MessagePending=ctypes.cast(self._cb_pending, ctypes.c_void_p).value,
+        )
+        self._impl = _IMessageFilterImpl(lpVtbl=ctypes.pointer(self._vtbl))
+        self._ptr = ctypes.cast(ctypes.pointer(self._impl), ctypes.c_void_p)
+
+    def register(self) -> None:
+        """Register this filter on the current STA thread.
+
+        Silently skips registration if COM is not initialized (e.g., in unit tests).
+        This is safe because the filter only provides enhanced behavior (dialog
+        suppression) — code works correctly without it, just with potential dialogs.
+        """
+        if self._registered:
+            return
+        try:
+            hr = _CoRegisterMessageFilter(self._ptr, ctypes.byref(self._old_filter))
+            if hr != 0:
+                _logger.debug(f"CoRegisterMessageFilter returned HRESULT=0x{hr:08X} — filter not active")
+            else:
+                self._registered = True
+                _logger.debug("IMessageFilter registered — 'Server Busy' dialogs suppressed")
+        except OSError as e:
+            # COM not initialized (e.g., unit tests without STA) — skip silently
+            _logger.debug(f"CoRegisterMessageFilter skipped (COM not initialized): {e}")
+
+    def unregister(self) -> None:
+        """Unregister this filter and restore the previous one."""
+        if not self._registered:
+            return
+        _CoRegisterMessageFilter(self._old_filter, ctypes.byref(ctypes.c_void_p()))
+        self._registered = False
+        _logger.debug("IMessageFilter unregistered")
+
+    def _on_handle_incoming(
+        self, this, dwCallType, htaskCaller, dwTickCount, lpInterfaceInfo
+    ) -> int:
+        return 0  # SERVERCALL_ISHANDLED
+
+    def _on_retry_rejected(
+        self, this, htaskCallee, dwTickCount, dwRejectType
+    ) -> int:
+        self._rejection_count += 1
+
+        # Log at key intervals
+        if dwTickCount == 0:
+            _logger.warning(f"COM call rejected — starting retry (type={dwRejectType})")
+        elif dwTickCount >= 1000 and self._last_log_time < 1000:
+            _logger.warning(f"COM call still busy after 1s (retries={self._rejection_count})")
+        elif dwTickCount >= 5000 and self._last_log_time < 5000:
+            _logger.warning(f"COM call still busy after 5s (retries={self._rejection_count})")
+        elif dwTickCount >= 30000 and self._last_log_time < 30000:
+            _logger.warning(f"COM call still busy after 30s (retries={self._rejection_count})")
+        self._last_log_time = dwTickCount
+
+        # Only retry for SERVERCALL_REJECTED (1) or SERVERCALL_RETRYLATER (2)
+        if dwRejectType not in (1, 2):
+            return self._CANCEL_CALL
+
+        # Exponential backoff
+        if dwTickCount < 1000:
+            return 100
+        elif dwTickCount < 5000:
+            return 500
+        elif dwTickCount < 30000:
+            return 2000
+        elif dwTickCount < 60000:
+            return 5000
+        else:
+            _logger.error(
+                f"COM call timeout after 60s — giving up (retries={self._rejection_count})"
+            )
+            return self._CANCEL_CALL
+
+    def _on_message_pending(self, this, htaskCallee, dwTickCount, dwPendingType) -> int:
+        return 1  # PENDINGMSG_WAITNOPROCESS (suppress "Server Busy" dialog)

--- a/tests/test_py_canoe.py
+++ b/tests/test_py_canoe.py
@@ -26,6 +26,7 @@ class TestStandalonePyCanoe:
         cls.canoe_cfg_online_setup = os.path.join(cls.demo_cfg_dir, "demo_online_setup.cfg")
 
     def test_open_new_quit_methods(self):
+        logger.info("test_open_new_quit_methods started".center(120, '-'))
         assert self.canoe_inst.new(auto_save=False, prompt_user=False)
         assert self.canoe_inst.quit()
         assert self.canoe_inst.open(canoe_cfg=self.canoe_cfg_dev, visible=True, auto_save=False, prompt_user=False)
@@ -45,6 +46,7 @@ class TestStandalonePyCanoe:
         assert self.canoe_inst.quit()
 
     def test_opening_different_cfgs_sequentially(self):
+        logger.info("test_opening_different_cfgs_sequentially started".center(120, '-'))
         assert self.canoe_inst.open(canoe_cfg=self.canoe_cfg_dev, visible=True, auto_save=False, prompt_user=False)
         assert self.canoe_inst.start_measurement()
         assert self.canoe_inst.stop_measurement()
@@ -59,6 +61,7 @@ class TestStandalonePyCanoe:
         wait(1)
 
     def test_attach_to_active_application(self):
+        logger.info("test_attach_to_active_application started".center(120, '-'))
         assert self.canoe_inst.open(canoe_cfg=self.canoe_cfg_dev, visible=True, auto_save=False, prompt_user=False)
         assert self.canoe_inst.start_measurement()
         assert self.canoe_inst.attach_to_active_application()
@@ -70,6 +73,7 @@ class TestStandalonePyCanoe:
         assert self.canoe_inst.stop_measurement()
 
     def test_meas_start_stop_restart_methods(self):
+        logger.info("test_meas_start_stop_restart_methods started".center(120, '-'))
         assert self.canoe_inst.open(canoe_cfg=self.canoe_cfg_dev, visible=True, auto_save=False, prompt_user=False)
         assert self.canoe_inst.start_measurement()
         assert self.canoe_inst.stop_measurement()
@@ -81,6 +85,7 @@ class TestStandalonePyCanoe:
         assert self.canoe_inst.quit()
 
     def test_meas_offline_start_stop_restart_methods(self):
+        logger.info("test_meas_offline_start_stop_restart_methods started".center(120, '-'))
         assert self.canoe_inst.open(canoe_cfg=self.canoe_cfg_offline)
         assert self.canoe_inst.add_offline_source_log_file(fr'{self.file_path}\demo_cfg\Logs\demo_log.blf')
         assert self.canoe_inst.start_measurement_in_animation_mode(animation_delay=200)
@@ -90,6 +95,7 @@ class TestStandalonePyCanoe:
         assert self.canoe_inst.stop_measurement()
 
     def test_meas_index_methods(self):
+        logger.info("test_meas_index_methods started".center(120, '-'))
         assert self.canoe_inst.open(canoe_cfg=self.canoe_cfg_dev, visible=True, auto_save=False, prompt_user=False)
         self.canoe_inst.get_measurement_index()
         assert self.canoe_inst.start_measurement()
@@ -102,12 +108,14 @@ class TestStandalonePyCanoe:
         assert self.canoe_inst.stop_measurement()
 
     def test_meas_save_saveas_methods(self):
+        logger.info("test_meas_save_saveas_methods started".center(120, '-'))
         assert self.canoe_inst.open(canoe_cfg=self.canoe_cfg_dev)
         assert self.canoe_inst.save_configuration()
         assert self.canoe_inst.save_configuration_as(path=fr'{self.file_path}\demo_cfg\demo_v10.cfg', major=10, minor=0, create_dir=True)
         wait(1)
 
     def test_bus_stats_canoe_ver_methods(self):
+        logger.info("test_bus_stats_canoe_ver_methods started".center(120, '-'))
         assert self.canoe_inst.open(canoe_cfg=self.canoe_cfg_dev, visible=True, auto_save=False, prompt_user=False)
         self.canoe_inst.get_canoe_version_info()
         assert self.canoe_inst.start_measurement()
@@ -116,6 +124,7 @@ class TestStandalonePyCanoe:
         assert self.canoe_inst.stop_measurement()
 
     def test_bus_signal_methods(self):
+        logger.info("test_bus_signal_methods started".center(120, '-'))
         self.canoe_inst.open(canoe_cfg=self.canoe_cfg_dev, visible=True, auto_save=False, prompt_user=False)
         self.canoe_inst.get_bus_databases_info('CAN', log_info=True)
         self.canoe_inst.get_bus_nodes_info('CAN', log_info=True)
@@ -133,6 +142,7 @@ class TestStandalonePyCanoe:
         assert sig_val == 1
 
     def test_ui_class_methods(self):
+        logger.info("test_ui_class_methods started".center(120, '-'))
         self.canoe_inst.open(canoe_cfg=self.canoe_cfg_dev)
         self.canoe_inst.ui_activate_desktop('Configuration')
         self.canoe_inst.enable_write_window_output_file(fr'{self.file_path}\demo_cfg\Logs\write_win.txt')
@@ -149,6 +159,7 @@ class TestStandalonePyCanoe:
         wait(1)
 
     def test_system_variable_methods(self):
+        logger.info("test_system_variable_methods started".center(120, '-'))
         self.canoe_inst.open(canoe_cfg=self.canoe_cfg_dev)
         assert self.canoe_inst.start_measurement()
         self.canoe_inst.set_system_variable_value('demo::level_two_1::sys_var2', 20)
@@ -178,6 +189,7 @@ class TestStandalonePyCanoe:
         wait(1)
 
     def test_diag_request_methods(self):
+        logger.info("test_diag_request_methods started".center(120, '-'))
         self.canoe_inst.open(canoe_cfg=self.canoe_cfg_diag)
         assert self.canoe_inst.start_measurement()
         resp = self.canoe_inst.send_diag_request('Door', 'DefaultSession_Start', False)
@@ -196,6 +208,7 @@ class TestStandalonePyCanoe:
         assert self.canoe_inst.stop_measurement()
 
     def test_replay_block_methods(self):
+        logger.info("test_replay_block_methods started".center(120, '-'))
         self.canoe_inst.open(canoe_cfg=self.canoe_cfg_dev, visible=True, auto_save=True, prompt_user=False, auto_stop=True)
         assert self.canoe_inst.start_measurement()
         wait(1)
@@ -208,6 +221,7 @@ class TestStandalonePyCanoe:
         assert self.canoe_inst.stop_measurement()
 
     def test_capl_methods(self):
+        logger.info("test_capl_methods started".center(120, '-'))
         self.canoe_inst.open(canoe_cfg=self.canoe_cfg_dev, visible=True, auto_save=True, prompt_user=False, auto_stop=True)
         self.canoe_inst.compile_all_capl_nodes()
         assert self.canoe_inst.start_measurement()
@@ -217,6 +231,7 @@ class TestStandalonePyCanoe:
         assert self.canoe_inst.stop_measurement()
 
     def test_test_setup_methods(self):
+        logger.info("test_test_setup_methods started".center(120, '-'))
         self.canoe_inst.open(canoe_cfg=self.canoe_cfg_test_setup)
         self.canoe_inst.ui_activate_desktop('TestSetup')
         assert self.canoe_inst.start_measurement()
@@ -231,6 +246,7 @@ class TestStandalonePyCanoe:
         assert self.canoe_inst.stop_measurement()
 
     def test_env_var_methods(self):
+        logger.info("test_env_var_methods started".center(120, '-'))
         self.canoe_inst.open(canoe_cfg=self.canoe_cfg_dev)
         assert self.canoe_inst.start_measurement()
         self.canoe_inst.set_environment_variable_value('int_var', 123.12)
@@ -244,6 +260,7 @@ class TestStandalonePyCanoe:
         assert self.canoe_inst.stop_measurement()
 
     def test_conf_gen_setup(self):
+        logger.info("test_conf_gen_setup started".center(120, '-'))
         self.canoe_inst.open(canoe_cfg=self.canoe_cfg_gen_db_setup)
         assert self.canoe_inst.start_measurement()
         wait(1)
@@ -255,6 +272,7 @@ class TestStandalonePyCanoe:
         assert self.canoe_inst.save_configuration()
 
     def test_get_compilation_result(self):
+        logger.info("test_get_compilation_result started".center(120, '-'))
         self.canoe_inst.open(canoe_cfg=self.canoe_cfg_dev, visible=True, auto_save=False, prompt_user=False)
         result = self.canoe_inst.application.configuration.get_compilation_result()
         assert isinstance(result, dict)
@@ -263,12 +281,14 @@ class TestStandalonePyCanoe:
         assert result["success"] is True
 
     def test_run_compilation(self):
+        logger.info("test_run_compilation started".center(120, '-'))
         self.canoe_inst.open(canoe_cfg=self.canoe_cfg_dev, visible=True, auto_save=False, prompt_user=False)
         result = self.canoe_inst.application.configuration.run_compilation()
         assert isinstance(result, bool)
         assert result is True
 
     def test_get_all_network_names(self):
+        logger.info("test_get_all_network_names started".center(120, '-'))
         self.canoe_inst.open(canoe_cfg=self.canoe_cfg_dev, visible=True, auto_save=False, prompt_user=False)
         names = self.canoe_inst.application.networks.get_all_network_names()
         assert isinstance(names, list)
@@ -276,6 +296,7 @@ class TestStandalonePyCanoe:
         assert all(isinstance(n, str) for n in names)
 
     def test_simulation_bus_names(self):
+        logger.info("test_simulation_bus_names started".center(120, '-'))
         self.canoe_inst.open(canoe_cfg=self.canoe_cfg_dev, visible=True, auto_save=False, prompt_user=False)
         names = self.canoe_inst.application.bus.get_simulation_bus_names()
         assert isinstance(names, list)
@@ -283,6 +304,7 @@ class TestStandalonePyCanoe:
         assert all(isinstance(n, str) for n in names)
 
     def test_simulation_database_paths(self):
+        logger.info("test_simulation_database_paths started".center(120, '-'))
         self.canoe_inst.open(canoe_cfg=self.canoe_cfg_dev, visible=True, auto_save=False, prompt_user=False)
         paths = self.canoe_inst.application.bus.get_simulation_database_paths()
         assert isinstance(paths, list)
@@ -290,12 +312,14 @@ class TestStandalonePyCanoe:
         assert all(isinstance(p, str) for p in paths)
 
     def test_get_all_namespace_names(self):
+        logger.info("test_get_all_namespace_names started".center(120, '-'))
         self.canoe_inst.open(canoe_cfg=self.canoe_cfg_dev, visible=True, auto_save=False, prompt_user=False)
         names = self.canoe_inst.application.system.get_all_namespace_names()
         assert isinstance(names, list)
         assert 'demo' in names
 
     def test_get_all_variables_in_namespace(self):
+        logger.info("test_get_all_variables_in_namespace started".center(120, '-'))
         self.canoe_inst.open(canoe_cfg=self.canoe_cfg_dev, visible=True, auto_save=False, prompt_user=False)
         variables = self.canoe_inst.application.system.get_all_variables_in_namespace('demo')
         assert isinstance(variables, list)
@@ -305,6 +329,7 @@ class TestStandalonePyCanoe:
         assert all('name' in v and 'value' in v and 'full_name' in v for v in variables)
 
     def test_logging(self):
+        logger.info("test_logging started".center(120, '-'))
         self.canoe_inst.open(canoe_cfg=self.canoe_cfg_online_setup)
         logging_blocks = self.canoe_inst.get_logging_blocks()
         print(logging_block.full_name for logging_block in logging_blocks)
@@ -317,6 +342,7 @@ class TestStandalonePyCanoe:
         assert self.canoe_inst.stop_measurement()
 
     def test_test_unit_methods(self):
+        logger.info("test_test_unit_methods started".center(120, '-'))
         self.canoe_inst.open(canoe_cfg=r'C:\Users\Public\Documents\Vector\CANoe\Sample Configurations 11.0.81\CAN\Diagnostics\UDSSystem\UDSSystem.cfg')
         assert self.canoe_inst.start_measurement()
         test_configurations = self.canoe_inst.get_test_configurations()
@@ -328,6 +354,7 @@ class TestStandalonePyCanoe:
         assert self.canoe_inst.stop_measurement()
     
     def test_profile_signal_performance(self):
+        logger.info("test_profile_signal_performance started".center(120, '-'))
         self.canoe_inst.open(canoe_cfg=self.canoe_cfg_dev, visible=True, auto_save=False, prompt_user=False)
         assert self.canoe_inst.start_measurement()
         wait(1)

--- a/tests/test_unit_message_filter.py
+++ b/tests/test_unit_message_filter.py
@@ -1,0 +1,143 @@
+"""Unit tests for COMRetryMessageFilter."""
+
+import ctypes
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestCOMRetryMessageFilter:
+    """Tests for the IMessageFilter implementation."""
+
+    @pytest.fixture
+    def filter_class(self):
+        """Import the filter class."""
+        from py_canoe.core.message_filter import COMRetryMessageFilter
+        return COMRetryMessageFilter
+
+    @pytest.fixture
+    def mock_co_register(self):
+        """Mock CoRegisterMessageFilter to avoid actual COM registration."""
+        with patch("py_canoe.core.message_filter._CoRegisterMessageFilter") as mock:
+            mock.return_value = 0  # S_OK
+            yield mock
+
+    def test_init_creates_vtable(self, filter_class, mock_co_register):
+        """Filter creates a valid COM vtable structure."""
+        f = filter_class()
+        assert f._vtbl is not None
+        assert f._impl is not None
+        assert f._ptr is not None
+        assert f._registered is False
+
+    def test_register_calls_co_register_message_filter(self, filter_class, mock_co_register):
+        """register() calls CoRegisterMessageFilter."""
+        f = filter_class()
+        f.register()
+        assert mock_co_register.called
+        assert f._registered is True
+
+    def test_register_twice_is_noop(self, filter_class, mock_co_register):
+        """Calling register() twice does not re-register."""
+        f = filter_class()
+        f.register()
+        f.register()
+        assert mock_co_register.call_count == 1
+
+    def test_unregister_restores_old_filter(self, filter_class, mock_co_register):
+        """unregister() restores the previous filter."""
+        f = filter_class()
+        f.register()
+        f.unregister()
+        assert mock_co_register.call_count == 2
+        assert f._registered is False
+
+    def test_unregister_without_register_is_noop(self, filter_class, mock_co_register):
+        """unregister() without prior register() is safe."""
+        f = filter_class()
+        f.unregister()
+        assert mock_co_register.call_count == 0
+
+    def test_on_handle_incoming_returns_handled(self, filter_class, mock_co_register):
+        """HandleInComingCall returns SERVERCALL_ISHANDLED (0)."""
+        f = filter_class()
+        result = f._on_handle_incoming(None, 0, None, 0, None)
+        assert result == 0
+
+    def test_on_message_pending_returns_waitnoprocess(self, filter_class, mock_co_register):
+        """MessagePending returns PENDINGMSG_WAITNOPROCESS (1)."""
+        f = filter_class()
+        result = f._on_message_pending(None, None, 0, 0)
+        assert result == 1
+
+    def test_retry_rejected_backoff_under_1s(self, filter_class, mock_co_register):
+        """RetryRejectedCall returns 100ms for first second."""
+        f = filter_class()
+        result = f._on_retry_rejected(None, None, 500, 1)  # 500ms, REJECTED
+        assert result == 100
+
+    def test_retry_rejected_backoff_1_to_5s(self, filter_class, mock_co_register):
+        """RetryRejectedCall returns 500ms for 1-5 seconds."""
+        f = filter_class()
+        result = f._on_retry_rejected(None, None, 2000, 1)  # 2s
+        assert result == 500
+
+    def test_retry_rejected_backoff_5_to_30s(self, filter_class, mock_co_register):
+        """RetryRejectedCall returns 2000ms for 5-30 seconds."""
+        f = filter_class()
+        result = f._on_retry_rejected(None, None, 10000, 1)  # 10s
+        assert result == 2000
+
+    def test_retry_rejected_backoff_30_to_60s(self, filter_class, mock_co_register):
+        """RetryRejectedCall returns 5000ms for 30-60 seconds."""
+        f = filter_class()
+        result = f._on_retry_rejected(None, None, 45000, 1)  # 45s
+        assert result == 5000
+
+    def test_retry_rejected_gives_up_after_60s(self, filter_class, mock_co_register):
+        """RetryRejectedCall returns CANCEL_CALL after 60 seconds."""
+        f = filter_class()
+        result = f._on_retry_rejected(None, None, 61000, 1)  # 61s
+        assert result == 0xFFFFFFFF  # _CANCEL_CALL
+
+    def test_retry_rejected_cancels_for_unknown_reject_type(self, filter_class, mock_co_register):
+        """RetryRejectedCall cancels for unknown reject types."""
+        f = filter_class()
+        result = f._on_retry_rejected(None, None, 100, 99)  # unknown type
+        assert result == 0xFFFFFFFF
+
+    def test_retry_rejected_accepts_retrylater(self, filter_class, mock_co_register):
+        """RetryRejectedCall retries for SERVERCALL_RETRYLATER (2)."""
+        f = filter_class()
+        result = f._on_retry_rejected(None, None, 100, 2)  # RETRYLATER
+        assert result == 100
+
+    def test_rejection_count_increments(self, filter_class, mock_co_register):
+        """Each retry increments the rejection counter."""
+        f = filter_class()
+        assert f._rejection_count == 0
+        f._on_retry_rejected(None, None, 0, 1)
+        assert f._rejection_count == 1
+        f._on_retry_rejected(None, None, 100, 1)
+        assert f._rejection_count == 2
+
+
+class TestApplicationMessageFilterIntegration:
+    """Tests that Application registers the message filter."""
+
+    @pytest.fixture
+    def mock_dependencies(self):
+        """Mock all COM dependencies."""
+        with patch("py_canoe.core.application.win32com.client") as mock_win32:
+            with patch("py_canoe.core.application.pythoncom"):
+                with patch("py_canoe.core.message_filter._CoRegisterMessageFilter") as mock_reg:
+                    mock_reg.return_value = 0
+                    yield {"win32com": mock_win32, "co_register": mock_reg}
+
+    def test_application_init_registers_filter(self, mock_dependencies):
+        """Application.__init__ registers the IMessageFilter."""
+        from py_canoe.core.application import Application
+        app = Application(enable_events=False)
+        assert app._message_filter is not None
+        assert app._message_filter._registered is True
+        assert mock_dependencies["co_register"].called

--- a/tests/test_unit_server_friendly.py
+++ b/tests/test_unit_server_friendly.py
@@ -280,34 +280,28 @@ class TestMeasurementStartEventsDisabled:
 # ---------------------------------------------------------------------------
 
 class TestStopExBusyRetry:
-    """Test stop_ex() busy-retry logic."""
+    """Test stop_ex() error handling.
+
+    Note: Busy-retry is now handled by IMessageFilter (registered in Application.__init__).
+    In unit tests without COM, the filter is not active, so stop_ex() simply returns False
+    on any exception. The IMessageFilter tests verify the retry logic separately.
+    """
 
     @patch("py_canoe.core.measurement.pythoncom.PumpWaitingMessages")
     @patch("py_canoe.core.measurement.time.sleep")
-    def test_stop_ex_retries_on_busy(self, mock_sleep, mock_pump):
+    def test_stop_ex_busy_returns_false_without_filter(self, mock_sleep, mock_pump):
+        """Without IMessageFilter (unit tests), busy exception returns False."""
         m, mock_com = _make_measurement(enable_events=False)
         mock_com.Running = True
+        mock_com.Stop = Mock(side_effect=Exception("User interface is busy (-2147418113)"))
 
-        call_count = [0]
-        def stop_side_effect():
-            call_count[0] += 1
-            if call_count[0] == 1:
-                raise Exception("User interface is busy (-2147418113)")
-            mock_com.Running = False
-
-        mock_com.Stop = Mock(side_effect=stop_side_effect)
-
-        # monotonic: 0 (t0), 0 (deadline check), 0 (Running check),
-        # 0 (Stop fail), 0 (elapsed log), 5.1 (next loop deadline check),
-        # 5.1 (Running check), 5.1 (Stop success), 5.1 (elapsed),
-        # 5.2 (poll), 5.2 (Running=False), 5.2 (final elapsed)
-        times = [0] * 5 + [5.1] * 5 + [5.2] * 5
+        times = [0] * 10
         time_iter = iter(times)
         with patch("py_canoe.core.measurement.time.monotonic", side_effect=lambda: next(time_iter)):
             result = m.stop_ex(timeout=30, post_stop_pump=0)
 
-        assert result is True
-        assert call_count[0] == 2
+        assert result is False
+        mock_com.Stop.assert_called_once()
 
     @patch("py_canoe.core.measurement.pythoncom.PumpWaitingMessages")
     @patch("py_canoe.core.measurement.time.sleep")


### PR DESCRIPTION
# Feature: COM Message Filter

## Motivation

CANoe sporadically shows "Server Busy" dialogs in server environments when COM calls occur during report generation or other busy phases. These dialogs block automated tests and require manual interaction.

## Changes

### New: `src/py_canoe/core/message_filter.py`

- `COMRetryMessageFilter`: IMessageFilter implementation via ctypes
- Automatic retry on `RPC_E_CALL_REJECTED` with exponential backoff (100ms → 500ms → 2s → 5s)
- Timeout after 60s
- Suppresses "Server Busy" dialog via `PENDINGMSG_WAITNOPROCESS`

### Changed: `src/py_canoe/core/application.py`

- Auto-registration of IMessageFilter in `Application.__init__()`
- No user code required — filter is automatically active

### Changed: `src/py_canoe/core/measurement.py`

- `stop_ex()`: Removed busy-retry logic (duplicate, since IMessageFilter handles this)
- Simplified code, same functionality

## API

No API changes. Existing code works unchanged.

## Technical Details

- `pythoncom` does not expose `CoRegisterMessageFilter` → ctypes implementation
- Filter is registered per STA thread
- Graceful degradation: If COM is not initialized (unit tests), registration is skipped


### request new release 
