### PR TITLE
Add option to prompt user on configuration save

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "py-canoe"
-version = "26.3.0"
+version = "26.2.6"
 description = "Python 🐍 Package for accessing Vector CANoe 🛶 Tool via COM Interface"
 license = { file = "LICENSE" }
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "py-canoe"
-version = "26.2.5"
+version = "26.3.0"
 description = "Python 🐍 Package for accessing Vector CANoe 🛶 Tool via COM Interface"
 license = { file = "LICENSE" }
 readme = "README.md"

--- a/src/py_canoe/core/configuration.py
+++ b/src/py_canoe/core/configuration.py
@@ -227,7 +227,7 @@ class Configuration:
                 return True
             if path == "":
                 path = self.full_name
-            self.com_object.Save(path=path, promtUser=prompt_user)
+            self.com_object.Save(path, promptUser)
             logger.info("CANoe configuration saved successfully ")
             return True
         except Exception as e:

--- a/src/py_canoe/core/configuration.py
+++ b/src/py_canoe/core/configuration.py
@@ -220,12 +220,14 @@ class Configuration:
         except Exception as e:
             return {"success": False, "error": str(e)}
 
-    def save(self, prompt_user: bool = False) -> bool:
+    def save(self, path: str = "", prompt_user: bool = False) -> bool:
         try:
             if self.saved:
                 logger.warning("CANoe configuration is already saved.")
                 return True
-            self.com_object.Save(promtUser = prompt_user)
+            if path == "":
+                path = self.full_name
+            self.com_object.Save(path=path, promtUser=prompt_user)
             logger.info("CANoe configuration saved successfully ")
             return True
         except Exception as e:

--- a/src/py_canoe/core/configuration.py
+++ b/src/py_canoe/core/configuration.py
@@ -220,12 +220,12 @@ class Configuration:
         except Exception as e:
             return {"success": False, "error": str(e)}
 
-    def save(self) -> bool:
+    def save(self, prompt_user: bool = False) -> bool:
         try:
             if self.saved:
                 logger.warning("CANoe configuration is already saved.")
                 return True
-            self.com_object.Save()
+            self.com_object.Save(promtUser = prompt_user)
             logger.info("CANoe configuration saved successfully ")
             return True
         except Exception as e:


### PR DESCRIPTION
Setting the default value to False as well as giving the option, is more flexible, prevents blocking any automated executions and it is also more consistent with the usage of the save_as function, as that one does offer that option already.