### PR TITLE
Delay CANoe configuration initialization until after open

### DIFF
--- a/src/py_canoe/core/application.py
+++ b/src/py_canoe/core/application.py
@@ -109,7 +109,6 @@ class Application:
             self.measurement = Measurement(self, enable_events=self._enable_events)
             self.capl_function_objects = lambda: self.measurement.measurement_events.CAPL_FUNCTION_OBJECTS
             self.measurement.measurement_events.CAPL_FUNCTION_NAMES = self.user_capl_functions
-            self._common_between_pre_and_post_cfg_open()
         except Exception as e:
             logger.error(f"Failed to launch CANoe application: {e}")
             raise

--- a/tests/test_unit_server_friendly.py
+++ b/tests/test_unit_server_friendly.py
@@ -74,10 +74,11 @@ class TestApplicationEnableEvents:
         mock_meas_cls.return_value = Mock(measurement_events=Mock())
 
         app = Application(enable_events=True)
-        with patch.object(app, "_common_between_pre_and_post_cfg_open"):
+        with patch.object(app, "_common_between_pre_and_post_cfg_open") as mock_common:
             app._launch_application()
 
         mock_with_events.assert_called_once()
+        mock_common.assert_not_called()
 
     @patch("py_canoe.core.application.Measurement")
     @patch("win32com.client.WithEvents")
@@ -89,10 +90,11 @@ class TestApplicationEnableEvents:
         mock_meas_cls.return_value = Mock(measurement_events=Mock())
 
         app = Application(enable_events=False)
-        with patch.object(app, "_common_between_pre_and_post_cfg_open"):
+        with patch.object(app, "_common_between_pre_and_post_cfg_open") as mock_common:
             app._launch_application()
 
         mock_with_events.assert_not_called()
+        mock_common.assert_not_called()
 
     @patch("py_canoe.core.application.Measurement")
     @patch("win32com.client.gencache.EnsureDispatch")
@@ -103,9 +105,10 @@ class TestApplicationEnableEvents:
         mock_meas_cls.return_value = Mock(measurement_events=Mock())
 
         app = Application(enable_events=False)
-        with patch.object(app, "_common_between_pre_and_post_cfg_open"):
+        with patch.object(app, "_common_between_pre_and_post_cfg_open") as mock_common:
             app._launch_application()
 
+        mock_common.assert_not_called()
         assert isinstance(app.application_events, ApplicationEvents)
         assert app.application_events.OPENED is False
 
@@ -118,9 +121,10 @@ class TestApplicationEnableEvents:
         mock_meas_cls.return_value = Mock(measurement_events=Mock())
 
         app = Application(enable_events=False)
-        with patch.object(app, "_common_between_pre_and_post_cfg_open"):
+        with patch.object(app, "_common_between_pre_and_post_cfg_open") as mock_common:
             app._launch_application()
 
+        mock_common.assert_not_called()
         mock_meas_cls.assert_called_once_with(app, enable_events=False)
 
 


### PR DESCRIPTION
### Motivation
- Prevent early COM dispatch to CANoe's `Configuration` object during application launch because instantiating `Configuration(self)` before a configuration file is loaded triggers opaque COM errors and leaves CANoe in a busy state.

### Description
- Removed the call to `_common_between_pre_and_post_cfg_open()` from `Application._launch_application()` so `Configuration(self)` is not created during launch (`src/py_canoe/core/application.py`).
- Left the shared initialization in `_setup_post_configuration_loading()` so objects (including `Configuration`) are initialized only after `Open()` and the OPENED event complete.
- Updated unit tests in `tests/test_unit_server_friendly.py` to assert `_common_between_pre_and_post_cfg_open()` is not called during `_launch_application()` for both event-enabled and polling modes.

### Testing
- `python -m py_compile src/py_canoe/core/application.py tests/test_unit_server_friendly.py` succeeded.
- `PYTHONPATH=src pytest tests/test_unit_server_friendly.py -q` could not complete in this environment because the Windows-only `win32com` package is not available, so full pytest verification was blocked.
- Performed basic static checks (`git diff --check`) and compile-time verification which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a283defa4388327aab133e8c39b9a3f)