### PR TITLE
Add FlexRay to bus_types

### DIFF
--- a/src/py_canoe/core/application.py
+++ b/src/py_canoe/core/application.py
@@ -42,7 +42,7 @@ class Application:
 
     def __init__(self, enable_events: bool = True) -> None:
         self._enable_events = enable_events
-        self.bus_types = {'CAN': 1, 'J1939': 2, 'FLEXRAY': 3, 'TTP': 4, 'LIN': 5, 'MOST': 6, 'Kline': 14}
+        self.bus_types = {'CAN': 1, 'J1939': 2, 'FLEXRAY': 3, 'TTP': 4, 'LIN': 5, 'MOST': 6, 'ETH': 7, 'Kline': 14}
         self.com_object = None
         self.application_events = None
         self.bus: Bus = None

--- a/src/py_canoe/core/application.py
+++ b/src/py_canoe/core/application.py
@@ -42,7 +42,7 @@ class Application:
 
     def __init__(self, enable_events: bool = True) -> None:
         self._enable_events = enable_events
-        self.bus_types = {'CAN': 1, 'J1939': 2, 'TTP': 4, 'LIN': 5, 'MOST': 6, 'Kline': 14}
+        self.bus_types = {'CAN': 1, 'J1939': 2, 'FLEXRAY': 3, 'TTP': 4, 'LIN': 5, 'MOST': 6, 'Kline': 14}
         self.com_object = None
         self.application_events = None
         self.bus: Bus = None


### PR DESCRIPTION
Issue:
Currently, py-canoe doesn't support Flexray due to it not being included in the bus_types list.

I've added it in the list and assigned it to 3 (Although I think that the number doesn't matter too much, since it also worked when I assigned it to another number).

I've tested this locally on my CANoe set up and I am able to Get Signals from Flexray.
