### PR TITLE
Add support for parametrized diag requests with symbolic request name

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,8 @@ resp = canoe_inst.send_diag_request('Door', '10 02')
 canoe_inst.control_tester_present('Door', False)
 wait(2)
 resp = canoe_inst.send_diag_request('Door', '10 03', return_sender_name=True)
+wait(2)
+resp = canoe_inst.send_diag_request('Door', 'Variant_Coding_Write', False, CountryType="Europe")
 canoe_inst.stop_measurement()
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "py-canoe"
-version = "26.2.8"
+version = "26.2.9"
 description = "Python 🐍 Package for accessing Vector CANoe 🛶 Tool via COM Interface"
 license = { file = "LICENSE" }
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "py-canoe"
-version = "26.3.8"
+version = "26.3.0"
 description = "Python 🐍 Package for accessing Vector CANoe 🛶 Tool via COM Interface"
 license = { file = "LICENSE" }
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "py-canoe"
-version = "26.2.9"
+version = "26.3.8"
 description = "Python 🐍 Package for accessing Vector CANoe 🛶 Tool via COM Interface"
 license = { file = "LICENSE" }
 readme = "README.md"

--- a/src/py_canoe/canoe.py
+++ b/src/py_canoe/canoe.py
@@ -72,7 +72,7 @@ class CANoe:
 
     def _reset_application(self):
         """Reset application reference without trying to clean up event sinks.
-        
+
         After a successful quit, the COM server is already shut down, so the event sinks
         are invalid. We just release the Python reference here.
         """
@@ -834,7 +834,7 @@ class CANoe:
         self.application.measurement.measurement_index = index
         return True
 
-    def send_diag_request(self, diag_ecu_qualifier_name: str, request: str, request_in_bytes=True, return_sender_name=False, response_in_bytearray=False, timeout: float = 30, poll_s: float = 0.01) -> Union[str, dict]:
+    def send_diag_request(self, diag_ecu_qualifier_name: str, request: str, request_in_bytes=True, return_sender_name=False, response_in_bytearray=False, timeout: float = 30, poll_s: float = 0.01, parameters:Optional[dict[str,int|str]]=None) -> Union[str, dict]:
         """
         Sends a diagnostic request.
 
@@ -846,11 +846,14 @@ class CANoe:
             response_in_bytearray (bool): Whether to return the response in bytearray.
             timeout (float): The timeout in seconds for the operation. Defaults to 30.
             poll_s (float): The polling interval in seconds to check for the response. Defaults to 0.01.
+            parameters (dict[str, str|int): Key-value pairs used for parametrization of non-bytes request.
 
         Returns:
             Union[str, dict]: The response from the diagnostic request.
         """
-        return self.application.networks.send_diag_request(diag_ecu_qualifier_name, request, request_in_bytes, return_sender_name, response_in_bytearray, timeout, poll_s)
+        if parameters is None:
+            parameters = {}
+        return self.application.networks.send_diag_request(diag_ecu_qualifier_name, request, request_in_bytes, return_sender_name, response_in_bytearray, timeout, poll_s, **parameters)
 
     def control_tester_present(self, diag_ecu_qualifier_name: str, value: bool) -> bool:
         """

--- a/src/py_canoe/canoe.py
+++ b/src/py_canoe/canoe.py
@@ -834,7 +834,7 @@ class CANoe:
         self.application.measurement.measurement_index = index
         return True
 
-    def send_diag_request(self, diag_ecu_qualifier_name: str, request: str, request_in_bytes=True, return_sender_name=False, response_in_bytearray=False, timeout: float = 30, poll_s: float = 0.01, parameters:Optional[dict[str,int|str]]=None) -> Union[str, dict]:
+    def send_diag_request(self, diag_ecu_qualifier_name: str, request: str, request_in_bytes=True, return_sender_name=False, response_in_bytearray=False, timeout: float = 30, poll_s: float = 0.01, parameters: Optional[dict[str, int|str]]=None) -> Union[str, dict]:
         """
         Sends a diagnostic request.
 

--- a/src/py_canoe/canoe.py
+++ b/src/py_canoe/canoe.py
@@ -834,7 +834,7 @@ class CANoe:
         self.application.measurement.measurement_index = index
         return True
 
-    def send_diag_request(self, diag_ecu_qualifier_name: str, request: str, request_in_bytes=True, return_sender_name=False, response_in_bytearray=False, timeout: float = 30, poll_s: float = 0.01, parameters: Optional[dict[str, int|str]]=None) -> Union[str, dict]:
+    def send_diag_request(self, diag_ecu_qualifier_name: str, request: str, request_in_bytes=True, return_sender_name=False, response_in_bytearray=False, timeout: float = 30, poll_s: float = 0.01, **kwargs) -> Union[str, dict]:
         """
         Sends a diagnostic request.
 
@@ -846,14 +846,15 @@ class CANoe:
             response_in_bytearray (bool): Whether to return the response in bytearray.
             timeout (float): The timeout in seconds for the operation. Defaults to 30.
             poll_s (float): The polling interval in seconds to check for the response. Defaults to 0.01.
-            parameters (dict[str, str|int): Key-value pairs used for parametrization of non-bytes request.
-
+            **kwargs (str | int): Key-value pairs used for parametrization of a non-bytes
+                request. Accepts symbolic interpretation of parameter value.
         Returns:
             Union[str, dict]: The response from the diagnostic request.
+
+        Example:
+            >>> self.send_diag_request("ECU", "WritePropulsionType", False, PropulsionType="BatteryElectric")
         """
-        if parameters is None:
-            parameters = {}
-        return self.application.networks.send_diag_request(diag_ecu_qualifier_name, request, request_in_bytes, return_sender_name, response_in_bytearray, timeout, poll_s, **parameters)
+        return self.application.networks.send_diag_request(diag_ecu_qualifier_name, request, request_in_bytes, return_sender_name, response_in_bytearray, timeout, poll_s, **kwargs)
 
     def control_tester_present(self, diag_ecu_qualifier_name: str, value: bool) -> bool:
         """

--- a/src/py_canoe/core/child_elements/diagnostic.py
+++ b/src/py_canoe/core/child_elements/diagnostic.py
@@ -12,15 +12,14 @@ class Diagnostic:
         return self.com_object.TesterPresentStatus
 
     def create_request(self, primitive_path, **kwargs) -> DiagnosticRequest:
-        req = self.com_object.CreateRequest(primitive_path)
+        request = self.com_object.CreateRequest(primitive_path)
         for key, value in kwargs.items():
             try:
-                req.SetParameter(key, value)
+                request.SetParameter(key, value)
             except com_error:
-                logger.error("Failed to create parametrized diagnostic request due to %s attribute.",
-                             key)
+                logger.error("Failed to create parametrized diagnostic request due to %s attribute.", key)
                 raise
-        return DiagnosticRequest(req)
+        return DiagnosticRequest(request)
 
     def create_request_from_stream(self, byte_stream: bytearray) -> DiagnosticRequest:
         return DiagnosticRequest(self.com_object.CreateRequestFromStream(byte_stream))

--- a/src/py_canoe/core/child_elements/diagnostic.py
+++ b/src/py_canoe/core/child_elements/diagnostic.py
@@ -1,5 +1,7 @@
-from py_canoe.core.child_elements.diagnostic_request import DiagnosticRequest
+from win32com.universal import com_error
 
+from py_canoe.core.child_elements.diagnostic_request import DiagnosticRequest
+from py_canoe.helpers.common import logger
 
 class Diagnostic:
     def __init__(self, com_object):
@@ -9,8 +11,16 @@ class Diagnostic:
     def tester_present_status(self) -> bool:
         return self.com_object.TesterPresentStatus
 
-    def create_request(self, primitive_path) -> DiagnosticRequest:
-        return DiagnosticRequest(self.com_object.CreateRequest(primitive_path))
+    def create_request(self, primitive_path, **kwargs) -> DiagnosticRequest:
+        req = self.com_object.CreateRequest(primitive_path)
+        for key, value in kwargs.items():
+            try:
+                req.SetParameter(key, value)
+            except com_error:
+                logger.error("Failed to create parametrized diagnostic request due to %s attribute.",
+                             key)
+                raise
+        return DiagnosticRequest(req)
 
     def create_request_from_stream(self, byte_stream: bytearray) -> DiagnosticRequest:
         return DiagnosticRequest(self.com_object.CreateRequestFromStream(byte_stream))

--- a/src/py_canoe/core/networks.py
+++ b/src/py_canoe/core/networks.py
@@ -1,5 +1,5 @@
 import time
-from typing import Union
+from typing import Union, Optional
 
 from py_canoe.helpers.common import logger
 from py_canoe.helpers.common import wait
@@ -53,7 +53,7 @@ class Networks:
             logger.error(f"Error fetching Diagnostic Devices: {e}")
             return None
 
-    def send_diag_request(self, diag_ecu_qualifier_name: str, request: str, request_in_bytes=True, return_sender_name=False, response_in_bytearray=False, timeout: float = 10.0, poll_s: float = 0.01) -> Union[str, dict]:
+    def send_diag_request(self, diag_ecu_qualifier_name: str, request: str, request_in_bytes=True, return_sender_name=False, response_in_bytearray=False, timeout: float = 10.0, poll_s: float = 0.01, **kwargs:dict[str,int|str]) -> Union[str, dict]:
         try:
             diag_devices = self.diagnostic_devices
             if not diag_devices or diag_ecu_qualifier_name not in diag_devices:
@@ -68,7 +68,7 @@ class Networks:
                         diag_req_in_bytes.append(int(byte_stream[i:i + 2], 16))
                     diag_request = diag_device.create_request_from_stream(diag_req_in_bytes)
                 else:
-                    diag_request = diag_device.create_request(request)
+                    diag_request = diag_device.create_request(request, **kwargs)
                 diag_request.send()
                 logger.info(f'{diag_ecu_qualifier_name}: Diagnostic Request = {request}')
                 start_time = time.time()

--- a/src/py_canoe/core/networks.py
+++ b/src/py_canoe/core/networks.py
@@ -53,7 +53,7 @@ class Networks:
             logger.error(f"Error fetching Diagnostic Devices: {e}")
             return None
 
-    def send_diag_request(self, diag_ecu_qualifier_name: str, request: str, request_in_bytes=True, return_sender_name=False, response_in_bytearray=False, timeout: float = 10.0, poll_s: float = 0.01, **kwargs:dict[str,int|str]) -> Union[str, dict]:
+    def send_diag_request(self, diag_ecu_qualifier_name: str, request: str, request_in_bytes=True, return_sender_name=False, response_in_bytearray=False, timeout: float = 10.0, poll_s: float = 0.01, **kwargs: dict[str, int|str]) -> Union[str, dict]:
         try:
             diag_devices = self.diagnostic_devices
             if not diag_devices or diag_ecu_qualifier_name not in diag_devices:

--- a/src/py_canoe/core/networks.py
+++ b/src/py_canoe/core/networks.py
@@ -53,7 +53,7 @@ class Networks:
             logger.error(f"Error fetching Diagnostic Devices: {e}")
             return None
 
-    def send_diag_request(self, diag_ecu_qualifier_name: str, request: str, request_in_bytes=True, return_sender_name=False, response_in_bytearray=False, timeout: float = 10.0, poll_s: float = 0.01, **kwargs: dict[str, int|str]) -> Union[str, dict]:
+    def send_diag_request(self, diag_ecu_qualifier_name: str, request: str, request_in_bytes=True, return_sender_name=False, response_in_bytearray=False, timeout: float = 10.0, poll_s: float = 0.01, **kwargs) -> Union[str, dict]:
         try:
             diag_devices = self.diagnostic_devices
             if not diag_devices or diag_ecu_qualifier_name not in diag_devices:

--- a/tests/test_py_canoe.py
+++ b/tests/test_py_canoe.py
@@ -1,5 +1,7 @@
 import os
 import pytest
+from win32com.universal import com_error
+
 from py_canoe import CANoe, wait
 from py_canoe.helpers.common import logger
 from tests.conftest import skip_if_no_canoe
@@ -205,6 +207,12 @@ class TestStandalonePyCanoe:
         assert resp.get('Door') == '50 03 00 00 00 00'
         resp = self.canoe_inst.send_diag_request('Door', '22 F1 AA', return_sender_name=True)
         assert '62 F1 AA' in resp.get('Door')
+        wait(2)
+        with pytest.raises(com_error):
+            self.canoe_inst.send_diag_request('Door', 'DefaultSession_Start', False, custom_parameter="CustomSetting")
+        wait(2)
+        resp = self.canoe_inst.send_diag_request('Door', 'Variant_Coding_Write', False, CountryType="Europe")
+        assert resp == '6E 00 A0'
         assert self.canoe_inst.stop_measurement()
 
     def test_replay_block_methods(self):


### PR DESCRIPTION
Adds `**kwargs` support to `send_diag_request`, allowing parametrization of symbolic diagnostic requests using parameter names defined in CDD file.