### PR TITLE
Release COM event sinks on the quit() success path

### DIFF
--- a/src/py_canoe/core/application.py
+++ b/src/py_canoe/core/application.py
@@ -233,12 +233,11 @@ class Application:
     def quit(self, timeout: int = 5) -> bool:
         """Quit CANoe and clean up COM references."""
         status = False
-        quit_called = False
         try:
             if self.configuration is not None:
                 self.configuration.modified = False
+            self._release_event_sinks(preserve_application_events=True)
             self.com_object.Quit()
-            quit_called = True
             status = DoEventsUntil(lambda: self.application_events.QUIT, timeout, "Quit CANoe application")
             if status:
                 logger.info("CANoe Application Quit Successfully.")
@@ -248,8 +247,7 @@ class Application:
             status = False
             return status
         finally:
-            if not quit_called:
-                self._release_event_sinks()
+            self._release_event_sinks()
 
     def attach_to_active_application(self) -> bool:
         """Attach to a active instance of the CANoe application."""


### PR DESCRIPTION
Application._release_event_sinks() was only invoked from quit()'s `finally` block under `if not quit_called`, i.e. only when com_object.Quit() was never reached. On the normal (successful) shutdown path the event sinks attached via win32com.client.WithEvents()
- application_events, measurement_events, and the per-test-configuration and per-test-module sinks - were never disconnected.

Those sink wrappers live inside the Application object graph, which is kept alive by reference cycles. Refcounting therefore never frees them when the owning thread drops its CANoe reference; they survive until the cyclic GC runs. That GC can fire later, on an arbitrary thread and at an arbitrary time. Finalizing a sink there calls EventsProxy.close() -> IConnectionPoint::Unadvise against a CANoe server that has already shut down, raising CO_E_OBJNOTCONNECTED (0x800401fd). When faulthandler is enabled this prints a noisy "Windows fatal exception" dump, even though win32com otherwise swallows the error.

The two-phase teardown mechanism already existed - _release_event_sinks() accepts preserve_application_events - but quit() never used it. Wire it up:

* Before com_object.Quit(), release every sink except application_events (preserve_application_events=True). The COM server is still alive, so each connection point is unadvised cleanly.
* Keep application_events connected across Quit() so the OnQuit event is still delivered to the DoEventsUntil() wait.
* In `finally`, always call _release_event_sinks() to disconnect application_events (and any stragglers left by an early failure). CANoe is gone by then, so this single disconnect targets a dead connection point; the existing com_error handling tolerates the stale HRESULTs. Sinks released in the first pass are already None and are skipped, so there is no double-close.

This performs the COM disconnects deterministically, on the thread that owns the COM apartment and while the server is alive, instead of deferring them to a late, cross-thread GC.