### PR TITLE
fix(application): initialize configuration when attaching to running …

### DIFF
--- a/src/py_canoe/core/application.py
+++ b/src/py_canoe/core/application.py
@@ -109,6 +109,11 @@ class Application:
             self.measurement = Measurement(self, enable_events=self._enable_events)
             self.capl_function_objects = lambda: self.measurement.measurement_events.CAPL_FUNCTION_OBJECTS
             self.measurement.measurement_events.CAPL_FUNCTION_NAMES = self.user_capl_functions
+            # When attaching to an already-running CANoe instance that has a project
+            # loaded, initialize the configuration and related objects so callers don't
+            # receive None from self.configuration.
+            if self.com_object.Configuration.FullName:
+                self._setup_post_configuration_loading()
         except Exception as e:
             logger.error(f"Failed to launch CANoe application: {e}")
             raise

--- a/tests/test_unit_server_friendly.py
+++ b/tests/test_unit_server_friendly.py
@@ -64,6 +64,13 @@ def _make_measurement(enable_events=False):
 # Application: enable_events
 # ---------------------------------------------------------------------------
 
+def _make_com_no_config() -> Mock:
+    """COM mock where CANoe is running but no project is loaded."""
+    com = Mock()
+    com.Configuration.FullName = ""
+    return com
+
+
 class TestApplicationEnableEvents:
     """Test Application with enable_events parameter."""
 
@@ -73,7 +80,7 @@ class TestApplicationEnableEvents:
     def test_enable_events_true_registers_with_events(
         self, mock_ensure, mock_with_events, mock_meas_cls
     ):
-        mock_ensure.return_value = Mock()
+        mock_ensure.return_value = _make_com_no_config()
         mock_with_events.return_value = Mock()
         mock_meas_cls.return_value = Mock(measurement_events=Mock())
 
@@ -90,7 +97,7 @@ class TestApplicationEnableEvents:
     def test_enable_events_false_skips_with_events(
         self, mock_ensure, mock_with_events, mock_meas_cls
     ):
-        mock_ensure.return_value = Mock()
+        mock_ensure.return_value = _make_com_no_config()
         mock_meas_cls.return_value = Mock(measurement_events=Mock())
 
         app = Application(enable_events=False)
@@ -105,7 +112,7 @@ class TestApplicationEnableEvents:
     def test_enable_events_false_creates_dummy_events(
         self, mock_ensure, mock_meas_cls
     ):
-        mock_ensure.return_value = Mock()
+        mock_ensure.return_value = _make_com_no_config()
         mock_meas_cls.return_value = Mock(measurement_events=Mock())
 
         app = Application(enable_events=False)
@@ -121,7 +128,7 @@ class TestApplicationEnableEvents:
     def test_measurement_created_with_enable_events_flag(
         self, mock_ensure, mock_meas_cls
     ):
-        mock_ensure.return_value = Mock()
+        mock_ensure.return_value = _make_com_no_config()
         mock_meas_cls.return_value = Mock(measurement_events=Mock())
 
         app = Application(enable_events=False)
@@ -130,6 +137,23 @@ class TestApplicationEnableEvents:
 
         mock_common.assert_not_called()
         mock_meas_cls.assert_called_once_with(app, enable_events=False)
+
+    @patch("py_canoe.core.application.Measurement")
+    @patch("win32com.client.gencache.EnsureDispatch")
+    def test_launch_initializes_config_when_already_loaded(
+        self, mock_ensure, mock_meas_cls
+    ):
+        """Attach to running CANoe with project loaded → _setup_post_configuration_loading called."""
+        com = Mock()
+        com.Configuration.FullName = "D:/path/to/GTS_Testing.cfg"
+        mock_ensure.return_value = com
+        mock_meas_cls.return_value = Mock(measurement_events=Mock())
+
+        app = Application(enable_events=False)
+        with patch.object(app, "_setup_post_configuration_loading") as mock_setup:
+            app._launch_application()
+
+        mock_setup.assert_called_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# fix(application): initialize configuration when attaching to running CANoe instance

## Problem

When attaching to an already-running CANoe instance that has a project loaded,
`self.configuration` (and `self.bus`, `self.system`, etc.) remain `None` after
`_launch_application()` returns.

Any subsequent access to these objects — for example `configuration.full_name` —
raises `AttributeError: 'NoneType' object has no attribute 'full_name'`, even though
CANoe is running and has a project open.

This affects any workflow where the Python process is started *after* CANoe is already
open with a configuration loaded (e.g. a server process, a test runner that attaches
to an existing session, or any tool that calls `_launch_application()` directly).

## Root Cause

`_setup_post_configuration_loading()` — which initializes `configuration`, `bus`,
`system`, `ui`, `version`, and related objects — is only called from the `open()` and
`open_config()` code paths.

`_launch_application()` connects to a running CANoe instance via
`gencache.EnsureDispatch("CANoe.Application")` but never calls
`_setup_post_configuration_loading()`, so all sub-objects stay `None` regardless of
what CANoe has open.

## Fix

After `_launch_application()` establishes the COM connection, check
`com_object.Configuration.FullName`. If it is non-empty, CANoe already has a project
loaded and `_setup_post_configuration_loading()` is called immediately:

```diff
+            if self.com_object.Configuration.FullName:
+                self._setup_post_configuration_loading()
```

If CANoe is running but has no project open, `FullName` is an empty string and
initialization is skipped — callers must still use `open_config()` or `open()` to
load a project as before.

## Test

Updated existing test mocks in `TestApplicationEnableEvents` to set
`Configuration.FullName = ""` (no project loaded), so the previous behaviour — no
initialization on a fresh attach — is preserved for those cases.

New test `test_launch_initializes_config_when_already_loaded` verifies that
`_setup_post_configuration_loading()` is called when `FullName` is non-empty.

All 86 unit tests pass.

## Regression Notes

- `open()` and `open_config()` are unaffected — they call `_setup_post_configuration_loading()`
  via their own code paths after the project has been opened.
- The fix only adds initialization in the attach path; it does not change any teardown
  or event-sink behaviour.
