### PR TITLE
feat: add test configuration case pattern selection to test config execution, test configuration case result  api and unit test case.

### DIFF
--- a/src/py_canoe/canoe.py
+++ b/src/py_canoe/canoe.py
@@ -559,6 +559,9 @@ class CANoe:
                                                                          match_by,
                                                                          wait_for_completion)
 
+    def get_test_configuration_cases_result(self, test_conf_name: str) -> dict:
+        return self.application.configuration.get_test_configurations_cases_result(test_conf_name)
+    
     def stop_test_configuration(self, test_configuration_name: str) -> bool:
         """stops execution of a specific test configuration.
 

--- a/src/py_canoe/canoe.py
+++ b/src/py_canoe/canoe.py
@@ -508,16 +508,25 @@ class CANoe:
         """Runs compilation for the current configuration."""
         return self.application.configuration.run_compilation()
 
-    def execute_all_test_configurations(self, wait_for_completion: bool = True) -> bool:
+    def execute_all_test_configurations(self, enable_test_cases: Sequence[str] = (), 
+                                       disable_test_cases: Sequence[str] = (), 
+                                       match_by: str = "name", 
+                                       wait_for_completion: bool = True) -> bool:
         """executes all test configurations available in test setup.
 
         Args:
+            enable_test_cases (Sequence[str]): Patterns of test cases to enable before execution.
+            disable_test_cases (Sequence[str]): Patterns of test cases to disable before execution.
+            match_by (str): Matching mode for patterns. One of "name", "group", or "fixture". Defaults to "name".
             wait_for_completion (bool): whether to wait for test configuration execution to complete before returning. defaults to True.
 
         Returns:
             bool: True if the operation was successful, False otherwise.
         """
-        return self.application.configuration.execute_all_test_configurations(wait_for_completion)
+        return self.application.configuration.execute_all_test_configurations(enable_test_cases, 
+                                                                            disable_test_cases, 
+                                                                            match_by,
+                                                                            wait_for_completion)
 
     def stop_all_test_configurations(self) -> bool:
         """stops execution of all test configurations available in test setup.
@@ -527,17 +536,28 @@ class CANoe:
         """
         return self.application.configuration.stop_all_test_configurations()
 
-    def execute_test_configuration(self, test_configuration_name: str, wait_for_completion: bool = True) -> bool:
+    def execute_test_configuration(self, test_configuration_name: str, 
+                                   enable_test_cases: Sequence[str] = (), 
+                                   disable_test_cases: Sequence[str] = (), 
+                                   match_by: str = "name", 
+                                   wait_for_completion: bool = True) -> bool:
         """executes a specific test configuration.
 
         Args:
             test_configuration_name (str): The name of the test configuration to execute.
+            enable_test_cases (Sequence[str]): Patterns of test cases to enable before execution.
+            disable_test_cases (Sequence[str]): Patterns of test cases to disable before execution.
+            match_by (str): Matching mode for patterns. One of "name", "group", or "fixture". Defaults to "name".
             wait_for_completion (bool): Whether to wait for the test configuration execution to complete before returning. Defaults to True.
 
         Returns:
             bool: True if the operation was successful, False otherwise.
         """
-        return self.application.configuration.execute_test_configuration(test_configuration_name, wait_for_completion)
+        return self.application.configuration.execute_test_configuration(test_configuration_name, 
+                                                                         enable_test_cases, 
+                                                                         disable_test_cases, 
+                                                                         match_by,
+                                                                         wait_for_completion)
 
     def stop_test_configuration(self, test_configuration_name: str) -> bool:
         """stops execution of a specific test configuration.

--- a/src/py_canoe/canoe_robot_lib.py
+++ b/src/py_canoe/canoe_robot_lib.py
@@ -437,17 +437,20 @@ class CanoeRobotLib:
         """Runs compilation for the current configuration."""
         return self._source.run_capl_compilation()
 
-    def canoe_execute_all_test_configurations(self, wait_for_completion: bool=True) -> bool:
+    def canoe_execute_all_test_configurations(self, enable_test_cases: Sequence[str]=(), disable_test_cases: Sequence[str]=(), match_by: str='name', wait_for_completion: bool=True) -> bool:
         """
         executes all test configurations available in test setup.
         
         Args:
+            enable_test_cases (Sequence[str]): Patterns of test cases to enable before execution.
+            disable_test_cases (Sequence[str]): Patterns of test cases to disable before execution.
+            match_by (str): Matching mode for patterns. One of "name", "group", or "fixture". Defaults to "name".
             wait_for_completion (bool): whether to wait for test configuration execution to complete before returning. defaults to True.
         
         Returns:
             bool: True if the operation was successful, False otherwise.
         """
-        return self._source.execute_all_test_configurations(wait_for_completion)
+        return self._source.execute_all_test_configurations(enable_test_cases, disable_test_cases, match_by, wait_for_completion)
 
     def canoe_stop_all_test_configurations(self) -> bool:
         """
@@ -458,18 +461,21 @@ class CanoeRobotLib:
         """
         return self._source.stop_all_test_configurations()
 
-    def canoe_execute_test_configuration(self, test_configuration_name: str, wait_for_completion: bool=True) -> bool:
+    def canoe_execute_test_configuration(self, test_configuration_name: str, enable_test_cases: Sequence[str]=(), disable_test_cases: Sequence[str]=(), match_by: str='name', wait_for_completion: bool=True) -> bool:
         """
         executes a specific test configuration.
         
         Args:
             test_configuration_name (str): The name of the test configuration to execute.
+            enable_test_cases (Sequence[str]): Patterns of test cases to enable before execution.
+            disable_test_cases (Sequence[str]): Patterns of test cases to disable before execution.
+            match_by (str): Matching mode for patterns. One of "name", "group", or "fixture". Defaults to "name".
             wait_for_completion (bool): Whether to wait for the test configuration execution to complete before returning. Defaults to True.
         
         Returns:
             bool: True if the operation was successful, False otherwise.
         """
-        return self._source.execute_test_configuration(test_configuration_name, wait_for_completion)
+        return self._source.execute_test_configuration(test_configuration_name, enable_test_cases, disable_test_cases, match_by, wait_for_completion)
 
     def canoe_stop_test_configuration(self, test_configuration_name: str) -> bool:
         """

--- a/src/py_canoe/core/child_elements/test_configurations.py
+++ b/src/py_canoe/core/child_elements/test_configurations.py
@@ -1,7 +1,8 @@
-
 import win32com.client
 
 from py_canoe.core.child_elements.test_configuration import TestConfiguration
+from py_canoe.core.child_elements.test_unit import TestUnit
+from py_canoe.core.child_elements.test_tree_elements import TestTreeElements
 
 
 class TestConfigurations:
@@ -28,3 +29,22 @@ class TestConfigurations:
             tc_inst = self.item(index)
             test_configurations[tc_inst.name] = tc_inst
         return test_configurations
+
+    def __get_elements_or_cases(self, title:str):
+        test_elements_or_cases = {}
+        test_confs = self.fetch_all_test_configurations()
+        for t_conf_name in test_confs.keys():
+            test_units_obj: dict[str, TestUnit] = test_confs[t_conf_name].test_units.fetch_all_test_units()
+            for tn_name in test_units_obj.keys():
+                test_elements: TestTreeElements= test_units_obj[tn_name].elements
+                if title == "elements":
+                    test_elements_or_cases[tn_name] = test_elements.fetch_all_test_tree_elements()
+                elif title == "case":
+                    test_elements.get_test_tree_element_cases(test_elements_or_cases)
+        return test_elements_or_cases
+    
+    def get_top_test_configurations_elements(self) -> dict:
+        return self.__get_elements_or_cases("elements")
+    
+    def get_all_test_configurations_cases(self) -> dict:
+        return self.__get_elements_or_cases("case")

--- a/src/py_canoe/core/child_elements/test_tree_element.py
+++ b/src/py_canoe/core/child_elements/test_tree_element.py
@@ -41,8 +41,8 @@ class TestTreeElement:
         return self.com_object.Id
 
     @property
-    def name(self) -> str:
-        return self.com_object.Name
+    def verdict(self) -> int:
+        return self.com_object.Verdict
 
     @property
     def type(self) -> TestTreeElementType:

--- a/src/py_canoe/core/child_elements/test_tree_elements.py
+++ b/src/py_canoe/core/child_elements/test_tree_elements.py
@@ -1,6 +1,6 @@
 import win32com.client
 
-from py_canoe.core.child_elements.test_tree_element import TestTreeElement
+from py_canoe.core.child_elements.test_tree_element import TestTreeElement, TestTreeElementType
 
 
 class TestTreeElements:
@@ -22,3 +22,14 @@ class TestTreeElements:
             tte_inst = self.item(index)
             test_tree_elements[tte_inst.caption] = tte_inst
         return test_tree_elements
+
+    def __traverse_and_collect(self, ttes_obj: 'TestTreeElements', test_cases: dict):
+        for tc_name, tte_obj in ttes_obj.fetch_all_test_tree_elements().items():
+            if (tte_obj.type == TestTreeElementType.TEST_GROUP) or (tte_obj.type == TestTreeElementType.TEST_FIXTURE):
+                if tte_obj.elements.count > 0:
+                    self.__traverse_and_collect(tte_obj.elements, test_cases)
+            else:
+                test_cases[tc_name] = {"tte_obj": tte_obj}
+            
+    def get_test_tree_element_cases(self, test_cases: dict):
+        self.__traverse_and_collect(self, test_cases)

--- a/src/py_canoe/core/configuration.py
+++ b/src/py_canoe/core/configuration.py
@@ -364,7 +364,7 @@ class Configuration:
                     while tc_inst.running:
                         wait(1)
                     logger.info(f'completed executing test configuration ({tc_name}) with verdict {tc_inst.test_configuration_events.VERDICT.name}')
-                return True
+            return True
         except Exception as e:
             logger.error(f'failed to execute test configuration. {e}')
             return False

--- a/src/py_canoe/core/configuration.py
+++ b/src/py_canoe/core/configuration.py
@@ -22,6 +22,8 @@ from py_canoe.core.child_elements.replay_collection import ReplayCollection
 from py_canoe.core.child_elements.simulation_setup import SimulationSetup
 from py_canoe.core.child_elements.test_configurations import TestConfigurations
 from py_canoe.core.child_elements.test_setup import TestSetup
+from py_canoe.core.child_elements.test_tree_elements import TestTreeElements, TestTreeElementType
+from py_canoe.core.child_elements.test_unit import TestUnit
 from py_canoe.helpers.common import logger, wait
 
 
@@ -356,9 +358,122 @@ class Configuration:
             logger.error(f'failed to get test configurations. {e}')
             return {}
 
-    def execute_all_test_configurations(self, wait_for_completion: bool = True) -> bool:
+    def get_test_configurations_cases_result(self, test_conf_name: str) -> dict:
+
+        if not test_conf_name: 
+            logger.warning("test_conf_name parameter is required.")
+            return {}
+        
+        verdict = {
+            0: "NotAvailable",
+            1: "Passed",
+            2: "Failed",
+            3: "None",
+            4: "Inconclusive",
+            5: "ErrorInTestSystem"
+        }
+        
+        test_cases = {}
+        for t_conf_name in self.__test_configurations.keys():
+            if t_conf_name != test_conf_name: continue
+            test_units_obj: dict[str, TestUnit] = self.__test_configurations[t_conf_name].test_units.fetch_all_test_units()
+            report_path = self.__test_configurations[t_conf_name].report.full_path
+            for tn_name in test_units_obj.keys():
+                test_elements: TestTreeElements = test_units_obj[tn_name].elements
+                test_elements.get_test_tree_element_cases(test_cases)
+        
+        return {
+            name: {
+                "enabled": value["tte_obj"].enabled,
+                "verdict": value["tte_obj"].verdict,
+                "verdict_name": verdict.get(value["tte_obj"].verdict, "Unknown"),
+                "report_path": report_path
+            }
+            for name, value in test_cases.items()
+        }
+    
+
+
+    def get_top_test_configurations_elements(self) -> dict:
+        return self.test_configurations.get_top_test_configurations_elements()
+    
+    def get_all_test_configurations_cases(self) -> dict:
+        return self.test_configurations.get_all_test_configurations_cases()
+
+    def enable_test_configurations_cases(self, tc_obj,
+                                         enable_patterns: Sequence[str] = (), 
+                                         disable_patterns: Sequence[str] = (), 
+                                         match_by: str = "name") -> None:
+        if match_by not in ("name","group", "fixture"):
+            logger.warning(f'Invalid match_by="{match_by}", falling back to "name".')
+            match_by = "name"
+
+        if isinstance(enable_patterns, str):
+            enable_patterns = [enable_patterns]
+        if isinstance(disable_patterns, str):
+            disable_patterns = [disable_patterns]
+
+        if not enable_patterns and not disable_patterns:
+            return
+
+        all_test_all_elements = self.get_top_test_configurations_elements()
+        all_test_cases = self.get_all_test_configurations_cases()
+
+        if not (all_test_cases or all_test_all_elements):
+            logger.warning(f'No test cases found in test module ({tc_obj}).')
+            return
+
+        if match_by in ("group", "fixture"):
+            match_flag =False
+            for all_ttes in all_test_all_elements.values():
+                for name, tts_obj in all_ttes.items():
+                    if tts_obj.type in (TestTreeElementType.TEST_GROUP, TestTreeElementType. TEST_FIXTURE):
+                        for pattern in enable_patterns:
+                            if self._match_test_case_name(name, pattern):
+                                match_flag = True
+                                tts_obj.enabled = True
+            if not match_flag:
+                logger.warning(f'Test configurations "{tc_obj}" has no test case titles available;'
+                                f'title patterns will not match anything, skipping selection.'
+                )
+                return
+
+        for tc_name, tc in all_test_cases.items():
+            should_enable = False
+            should_disable = False
+
+            for pattern in disable_patterns:
+                if self._match_test_case_name(tc_name, pattern):
+                    should_disable = True
+                    break
+
+            if not should_disable:
+                for pattern in enable_patterns:
+                    if self._match_test_case_name(tc_name, pattern):
+                        should_enable = True
+                        break
+
+            if should_disable:
+                if tc['tte_obj'].enabled:
+                    tc['tte_obj'].enabled = False
+                    logger.info(f'Test case "{tc_name}" disabled by pattern match.')
+            elif should_enable:
+                if not tc['tte_obj'].enabled:
+                    tc['tte_obj'].enabled = True
+                    logger.info(f'Test case "{tc_name}" enabled by pattern match.')
+
+
+
+    def execute_all_test_configurations(self, enable_test_case: Sequence[str] = (), 
+                                        disable_test_case: Sequence[str] = (),
+                                        match_by: str = "name",
+                                        wait_for_completion: bool = True) -> bool:
         try:
             for tc_name, tc_inst in self.__test_configurations.items():
+                self.enable_test_configurations_cases(self.__test_configurations[tc_name],
+                                                      enable_test_case,
+                                                      disable_test_case,
+                                                      match_by)
                 tc_inst.start()
                 if wait_for_completion:
                     while tc_inst.running:
@@ -379,9 +494,17 @@ class Configuration:
             logger.error(f'failed to stop test configuration. {e}')
             return False
 
-    def execute_test_configuration(self, tc_name: str, wait_for_completion: bool = True) -> bool:
+    def execute_test_configuration(self, tc_name: str, enable_test_case: Sequence[str] = (),
+                                   disable_test_case: Sequence[str] = (),
+                                   match_by: str = "name",
+                                   wait_for_completion: bool = True) -> bool:
         try:
             if tc_name in self.__test_configurations.keys():
+                self.enable_test_configurations_cases(self.__test_configurations[tc_name],
+                                                      enable_test_case,
+                                                      disable_test_case,
+                                                      match_by)
+                
                 tc_inst = self.__test_configurations[tc_name]
                 tc_inst.start()
                 if wait_for_completion:

--- a/tests/test_unit_test_module.py
+++ b/tests/test_unit_test_module.py
@@ -9,10 +9,11 @@ Unit tests for test module and test case features:
 - Configuration.get_test_module_result (report + test case verdicts)
 """
 
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock, patch, PropertyMock
 
 from py_canoe.core.child_elements.test_case import TestCase
 from py_canoe.core.child_elements.test_module import TestModule
+from py_canoe.core.child_elements.test_tree_element import TestTreeElement, TestTreeElementType
 from py_canoe.core.configuration import Configuration
 
 
@@ -850,4 +851,423 @@ class TestGetTestModuleResult:
         cfg._Configuration__test_modules = []
         with patch("py_canoe.core.configuration.Configuration._find_test_module", side_effect=Exception("error")):
             assert cfg.get_test_module_result("TestMod1") == {}
+
+
+# ===========================================================================
+# Configuration.enable_test_configurations_cases
+# ===========================================================================
+
+class TestEnableTestConfigurationsCases:
+    """Test enable_test_configurations_cases with mocked elements/cases."""
+
+    def _make_cfg(self):
+        cfg = Configuration.__new__(Configuration)
+        cfg._Configuration__test_configurations = {}
+        return cfg
+
+    # --- Empty patterns ---
+
+    def test_empty_patterns_does_nothing(self):
+        cfg = self._make_cfg()
+        tc_obj = MagicMock()
+
+        with patch.object(cfg, "get_top_test_configurations_elements") as mock_el, \
+             patch.object(cfg, "get_all_test_configurations_cases") as mock_cases:
+            cfg.enable_test_configurations_cases(tc_obj, (), ())
+
+        mock_el.assert_not_called()
+        mock_cases.assert_not_called()
+
+    def test_no_patterns_does_nothing(self):
+        cfg = self._make_cfg()
+        tc_obj = MagicMock()
+
+        with patch.object(cfg, "get_top_test_configurations_elements") as mock_el, \
+             patch.object(cfg, "get_all_test_configurations_cases") as mock_cases:
+            cfg.enable_test_configurations_cases(tc_obj)
+
+        mock_el.assert_not_called()
+        mock_cases.assert_not_called()
+
+    # --- match_by="name" with enable patterns ---
+
+    def test_enable_pattern_enables_matching_cases(self):
+        cfg = self._make_cfg()
+        tc_obj = MagicMock()
+
+        tce1 = MagicMock(spec=TestTreeElement)
+        tce1.enabled = False
+        tce2 = MagicMock(spec=TestTreeElement)
+        tce2.enabled = False
+
+        cfg.get_top_test_configurations_elements = MagicMock(return_value={})
+        cfg.get_all_test_configurations_cases = MagicMock(return_value={
+            "TC_001": {"tte_obj": tce1},
+            "TC_002": {"tte_obj": tce2},
+        })
+
+        cfg.enable_test_configurations_cases(tc_obj, enable_patterns=["TC_001"])
+
+        assert tce1.enabled is True
+        assert tce2.enabled is False
+
+    def test_enable_wildcard_pattern(self):
+        cfg = self._make_cfg()
+        tc_obj = MagicMock()
+
+        tce1 = MagicMock(spec=TestTreeElement)
+        tce1.enabled = False
+        tce2 = MagicMock(spec=TestTreeElement)
+        tce2.enabled = False
+
+        cfg.get_top_test_configurations_elements = MagicMock(return_value={})
+        cfg.get_all_test_configurations_cases = MagicMock(return_value={
+            "TC_001": {"tte_obj": tce1},
+            "TC_002": {"tte_obj": tce2},
+        })
+
+        cfg.enable_test_configurations_cases(tc_obj, enable_patterns=["TC_00*"])
+
+        assert tce1.enabled is True
+        assert tce2.enabled is True
+
+    # --- match_by="name" with disable patterns ---
+
+    def test_disable_pattern_disables_matching_cases(self):
+        cfg = self._make_cfg()
+        tc_obj = MagicMock()
+
+        tce1 = MagicMock(spec=TestTreeElement)
+        tce1.enabled = True
+        tce2 = MagicMock(spec=TestTreeElement)
+        tce2.enabled = True
+
+        cfg.get_top_test_configurations_elements = MagicMock(return_value={})
+        cfg.get_all_test_configurations_cases = MagicMock(return_value={
+            "TC_001": {"tte_obj": tce1},
+            "TC_slow": {"tte_obj": tce2},
+        })
+
+        cfg.enable_test_configurations_cases(tc_obj, disable_patterns=["*slow*"])
+
+        assert tce1.enabled is True
+        assert tce2.enabled is False
+
+    # --- Disable takes precedence ---
+
+    def test_disable_takes_precedence(self):
+        cfg = self._make_cfg()
+        tc_obj = MagicMock()
+
+        tce = MagicMock(spec=TestTreeElement)
+        tce.enabled = True
+
+        cfg.get_top_test_configurations_elements = MagicMock(return_value={})
+        cfg.get_all_test_configurations_cases = MagicMock(return_value={
+            "TC_slow_001": {"tte_obj": tce},
+        })
+
+        cfg.enable_test_configurations_cases(tc_obj, enable_patterns=["*"], disable_patterns=["*slow*"])
+
+        assert tce.enabled is False
+
+    # --- String pattern (not list) ---
+
+    def test_string_pattern_not_iterated_char_by_char(self):
+        cfg = self._make_cfg()
+        tc_obj = MagicMock()
+
+        tce1 = MagicMock(spec=TestTreeElement)
+        tce1.enabled = False
+        tce2 = MagicMock(spec=TestTreeElement)
+        tce2.enabled = False
+
+        cfg.get_top_test_configurations_elements = MagicMock(return_value={})
+        cfg.get_all_test_configurations_cases = MagicMock(return_value={
+            "TC_001": {"tte_obj": tce1},
+            "TC_071": {"tte_obj": tce2},
+        })
+
+        cfg.enable_test_configurations_cases(tc_obj, enable_patterns="TC_001")
+
+        assert tce1.enabled is True
+        assert tce2.enabled is False
+
+    # --- match_by="group" / "fixture" ---
+
+    def test_match_by_group_enables_matching_groups(self):
+        cfg = self._make_cfg()
+        tc_obj = MagicMock()
+
+        group_tte = MagicMock(spec=TestTreeElement)
+        group_tte.type = TestTreeElementType.TEST_GROUP
+        group_tte.enabled = False
+        case_tte = MagicMock(spec=TestTreeElement)
+        case_tte.enabled = False
+
+        cfg.get_top_test_configurations_elements = MagicMock(return_value={
+            "TU1": {"Group1": group_tte, "TC_001": case_tte},
+        })
+        cfg.get_all_test_configurations_cases = MagicMock(return_value={})
+
+        cfg.enable_test_configurations_cases(tc_obj, enable_patterns=["Group*"], match_by="group")
+
+        assert group_tte.enabled is True
+        assert case_tte.enabled is False
+
+    def test_match_by_fixture_enables_matching_fixtures(self):
+        cfg = self._make_cfg()
+        tc_obj = MagicMock()
+
+        fix_tte = MagicMock(spec=TestTreeElement)
+        fix_tte.type = TestTreeElementType.TEST_FIXTURE
+        fix_tte.enabled = False
+        case_tte = MagicMock(spec=TestTreeElement)
+        case_tte.enabled = False
+
+        cfg.get_top_test_configurations_elements = MagicMock(return_value={
+            "TU1": {"Fixture1": fix_tte, "TC_001": case_tte},
+        })
+        cfg.get_all_test_configurations_cases = MagicMock(return_value={})
+
+        cfg.enable_test_configurations_cases(tc_obj, enable_patterns=["Fixture*"], match_by="fixture")
+
+        assert fix_tte.enabled is True
+        assert case_tte.enabled is False
+
+    # --- Invalid match_by ---
+
+    def test_invalid_match_by_falls_back_to_name(self):
+        cfg = self._make_cfg()
+        tc_obj = MagicMock()
+
+        tce = MagicMock(spec=TestTreeElement)
+        tce.enabled = False
+
+        cfg.get_top_test_configurations_elements = MagicMock(return_value={})
+        cfg.get_all_test_configurations_cases = MagicMock(return_value={
+            "TC_001": {"tte_obj": tce},
+        })
+
+        cfg.enable_test_configurations_cases(tc_obj, enable_patterns=["TC_001"], match_by="invalid")
+
+        assert tce.enabled is True
+
+    # --- No test cases ---
+
+    def test_no_test_cases_warns_and_returns(self):
+        cfg = self._make_cfg()
+        tc_obj = MagicMock()
+
+        cfg.get_top_test_configurations_elements = MagicMock(return_value={})
+        cfg.get_all_test_configurations_cases = MagicMock(return_value={})
+
+        with patch("py_canoe.core.configuration.logger.warning") as mock_warn:
+            cfg.enable_test_configurations_cases(tc_obj, enable_patterns=["*"])
+
+        mock_warn.assert_called_once()
+        assert "No test cases found" in mock_warn.call_args[0][0]
+
+    # --- group/fixture with no match ---
+
+    def test_group_mode_no_match_warns_and_returns(self):
+        cfg = self._make_cfg()
+        tc_obj = MagicMock()
+
+        group_tte = MagicMock(spec=TestTreeElement)
+        group_tte.type = TestTreeElementType.TEST_GROUP
+        group_tte.enabled = False
+
+        cfg.get_top_test_configurations_elements = MagicMock(return_value={
+            "TU1": {"Group1": group_tte},
+        })
+        cfg.get_all_test_configurations_cases = MagicMock(return_value={})
+
+        with patch("py_canoe.core.configuration.logger.warning") as mock_warn:
+            cfg.enable_test_configurations_cases(tc_obj, enable_patterns=["NoMatch*"], match_by="group")
+
+        mock_warn.assert_called_once()
+        assert "no test case titles" in mock_warn.call_args[0][0]
+        assert group_tte.enabled is False
+
+
+# ===========================================================================
+# Configuration.get_test_configurations_cases_result
+# ===========================================================================
+
+class TestGetTestConfigurationsCasesResult:
+    """Test get_test_configurations_cases_result."""
+
+    def _make_test_conf_mock(self, name, report_path, test_units_data=None):
+        """Create a mocked TestConfiguration with test_units and report."""
+        if test_units_data is None:
+            test_units_data = {"TU1": {"TC_001": MagicMock(spec=TestTreeElement)}}
+
+        tc = MagicMock()
+        tc.name = name
+
+        # Mock test_units.fetch_all_test_units -> returns dict of TestUnit mocks
+        tu_mocks = {}
+        for tu_name, cases in test_units_data.items():
+            tu = MagicMock()
+            elements = MagicMock()
+            elements.get_test_tree_element_cases = lambda cases_dict, c=cases: cases_dict.update(c)
+            tu.elements = elements
+            tu_mocks[tu_name] = tu
+
+        tc.test_units.fetch_all_test_units = MagicMock(return_value=tu_mocks)
+
+        # Mock report.full_path
+        tc.report.full_path = report_path
+
+        return tc
+
+    def test_returns_verdict_info_for_matching_config(self):
+        cfg = Configuration.__new__(Configuration)
+        tce = MagicMock(spec=TestTreeElement)
+        tce.enabled = True
+        tce.verdict = 1
+
+        test_conf = self._make_test_conf_mock(
+            "TC1", "C:/report.xml",
+            {"TU1": {"TCase1": {"tte_obj": tce}}}
+        )
+        cfg._Configuration__test_configurations = {"TC1": test_conf}
+
+        result = cfg.get_test_configurations_cases_result("TC1")
+
+        assert "TCase1" in result
+        assert result["TCase1"]["enabled"] is True
+        assert result["TCase1"]["verdict"] == 1
+        assert result["TCase1"]["verdict_name"] == "Passed"
+        assert result["TCase1"]["report_path"] == "C:/report.xml"
+
+    def test_empty_string_returns_empty_dict(self):
+        cfg = Configuration.__new__(Configuration)
+        cfg._Configuration__test_configurations = {}
+
+        with patch("py_canoe.core.configuration.logger.warning") as mock_warn:
+            result = cfg.get_test_configurations_cases_result("")
+
+        assert result == {}
+        mock_warn.assert_called_once()
+
+    def test_nonexistent_config_returns_empty_dict(self):
+        cfg = Configuration.__new__(Configuration)
+        cfg._Configuration__test_configurations = {"TC1": MagicMock()}
+
+        result = cfg.get_test_configurations_cases_result("NonExistent")
+
+        assert result == {}
+
+    def test_verdict_mapping_all_values(self):
+        cfg = Configuration.__new__(Configuration)
+
+        cases = {}
+        for verdict_val, expected_name in [(0, "NotAvailable"), (1, "Passed"), (2, "Failed"),
+                                           (3, "None"), (4, "Inconclusive"), (5, "ErrorInTestSystem")]:
+            tce = MagicMock(spec=TestTreeElement)
+            tce.enabled = True
+            tce.verdict = verdict_val
+            cases[f"TC_{verdict_val}"] = {"tte_obj": tce}
+
+        test_conf = self._make_test_conf_mock("TC1", "C:/r.xml", {"TU1": cases})
+        cfg._Configuration__test_configurations = {"TC1": test_conf}
+
+        result = cfg.get_test_configurations_cases_result("TC1")
+
+        for verdict_val, expected_name in [(0, "NotAvailable"), (1, "Passed"), (2, "Failed"),
+                                           (3, "None"), (4, "Inconclusive"), (5, "ErrorInTestSystem")]:
+            assert result[f"TC_{verdict_val}"]["verdict_name"] == expected_name
+
+    def test_unknown_verdict_defaults_to_unknown(self):
+        cfg = Configuration.__new__(Configuration)
+
+        tce = MagicMock(spec=TestTreeElement)
+        tce.enabled = True
+        tce.verdict = 99
+
+        test_conf = self._make_test_conf_mock("TC1", "C:/r.xml", {"TU1": {"TC_X": {"tte_obj": tce}}})
+        cfg._Configuration__test_configurations = {"TC1": test_conf}
+
+        result = cfg.get_test_configurations_cases_result("TC1")
+
+        assert result["TC_X"]["verdict_name"] == "Unknown"
+
+
+# ===========================================================================
+# Configuration.execute_all_test_configurations with patterns
+# ===========================================================================
+
+class TestExecuteAllTestConfigurationsWithPatterns:
+    """Test execute_all_test_configurations forwards patterns correctly."""
+
+    def test_forwards_enable_disable_patterns(self):
+        cfg = Configuration.__new__(Configuration)
+        cfg._Configuration__test_configurations = {"TC1": MagicMock(), "TC2": MagicMock()}
+
+        with patch.object(cfg, "enable_test_configurations_cases") as mock_enable:
+            cfg.execute_all_test_configurations(
+                enable_test_case=["*"],
+                disable_test_case=["*slow*"],
+                match_by="name",
+                wait_for_completion=False
+            )
+
+        assert mock_enable.call_count == 2
+        for call in mock_enable.call_args_list:
+            assert call.args[1] == ["*"]
+            assert call.args[2] == ["*slow*"]
+            assert call.args[3] == "name"
+
+    def test_defaults_empty_patterns(self):
+        cfg = Configuration.__new__(Configuration)
+        tc1 = MagicMock()
+        cfg._Configuration__test_configurations = {"TC1": tc1}
+
+        with patch.object(cfg, "enable_test_configurations_cases") as mock_enable:
+            cfg.execute_all_test_configurations(wait_for_completion=False)
+
+        mock_enable.assert_called_once()
+        assert mock_enable.call_args[0][1] == ()
+        assert mock_enable.call_args[0][2] == ()
+        assert mock_enable.call_args[0][3] == "name"
+
+
+# ===========================================================================
+# Configuration.execute_test_configuration with patterns
+# ===========================================================================
+
+class TestExecuteTestConfigurationWithPatterns:
+    """Test execute_test_configuration forwards patterns correctly."""
+
+    def test_forwards_enable_disable_patterns(self):
+        cfg = Configuration.__new__(Configuration)
+        cfg._Configuration__test_configurations = {"TC1": MagicMock()}
+
+        with patch.object(cfg, "enable_test_configurations_cases") as mock_enable:
+            cfg.execute_test_configuration(
+                "TC1",
+                enable_test_case=["*"],
+                disable_test_case=["*slow*"],
+                match_by="name",
+                wait_for_completion=False
+            )
+
+        mock_enable.assert_called_once()
+        assert mock_enable.call_args[0][1] == ["*"]
+        assert mock_enable.call_args[0][2] == ["*slow*"]
+        assert mock_enable.call_args[0][3] == "name"
+
+    def test_defaults_empty_patterns(self):
+        cfg = Configuration.__new__(Configuration)
+        cfg._Configuration__test_configurations = {"TC1": MagicMock()}
+
+        with patch.object(cfg, "enable_test_configurations_cases") as mock_enable:
+            cfg.execute_test_configuration("TC1", wait_for_completion=False)
+
+        mock_enable.assert_called_once()
+        assert mock_enable.call_args[0][1] == ()
+        assert mock_enable.call_args[0][2] == ()
+        assert mock_enable.call_args[0][3] == "name"
 


### PR DESCRIPTION
### Summary
This PR fix a COM interface issue and enhance the module **test configrations**  operation.(test in CANoe17,Vteststudio8)

**1. fix the test configurations bug.**

- delete the class `TestTreeElement` function `name` and add function `verdict`.

- fix the issue of the function `execute_all_test_configurations` 

**2. add test configuration case pattern selection to test config execution, test configuration case result  api**

- Add `get_test_tree_element_cases` ,  `__traverse_and_collect `in class `TestTreeElements` 
- Add `get_all_test_configurations_cases`, `get_top_test_configurations_elements`, `__get_elements_or_cases `in class `TestConfigurations`.
- Add `get_test_configurations_cases_result`, `get_top_test_configurations_elements`, `get_all_test_configurations_cases`, `enable_test_configurations_cases`, in class `Configuration`
- enhance the function `execute_test_configuration`, `execute_all_test_configurations  `in class `Configuration` and class `CANoe`
 
### Test plan

- tests/test_unit_test_module.py all pass 

### Notes
Files touched: canoe.py, configuration.py, test_configurations.py,  canoe_robot_lib.py, test_tree_element.py, test_tree_elements.pytest_unit_test_module.py .