### PR TITLE
feat: enhance test setup objects with TestModule/TestSetupItem/TestReport wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,45 @@ canoe_inst.execute_test_module('demo_test_node_002')
 canoe_inst.stop_measurement()
 ```
 
+### create test environment and add test modules / folders
+
+`add_testEnvironments` creates (or loads from a file) a test environment and returns a `TestEnvironment` object that supports adding test modules and folders directly, without fetching the `items` collection first.
+
+```python
+from py_canoe import CANoe
+
+canoe_inst = CANoe()
+canoe_inst.open(canoe_cfg=r'tests\demo_cfg\demo_test_setup.cfg')
+
+# Create a new test environment (by name)
+test_env = canoe_inst.add_testEnvironments('NewTestEnv')
+
+# Load an existing test environment from a file (by path)
+# test_env = canoe_inst.add_testEnvironments(r'path\to\test_environment.stenv')
+
+# Add a test module: pass the file path of a CAPL program (.can)
+# or an XML test description (.tse/.stse/.vxt)
+test_module = test_env.add_test_module(r'path\to\TestCapl.can')
+
+# Optional `name` argument: rename immediately after adding
+test_module = test_env.add_test_module(r'path\to\TestCapl.can', name='My Test Module')
+print(test_module.name)  # My Test Module
+
+# Add a folder
+test_folder = test_env.add_folder('TestFolder')
+
+# Rename after adding (the COM Name property is writable in practice)
+test_module.name = 'Renamed Module'
+test_folder.name = 'Renamed Folder'
+
+# Recursively fetch all test modules in the environment (including those in folders)
+all_modules = test_env.get_all_test_modules()
+
+# Access report settings
+report = test_env.report
+print(report.last_written_full_name)  # path of the last generated test report
+```
+
 ### execute test module with selective test case enable/disable
 
 The `execute_test_module` method supports selectively enabling or disabling test cases before execution using wildcard or regex patterns.

--- a/README_CN.md
+++ b/README_CN.md
@@ -336,6 +336,44 @@ canoe_inst.execute_test_module('demo_test_node_002')
 canoe_inst.stop_measurement()
 ```
 
+### 创建测试环境并添加测试模块 / 文件夹
+
+`add_testEnvironments` 用于创建（或从文件加载）测试环境，返回的 `TestEnvironment` 对象支持直接添加测试模块和文件夹，无需先获取 `items` 集合。
+
+```python
+from py_canoe import CANoe
+
+canoe_inst = CANoe()
+canoe_inst.open(canoe_cfg=r'tests\demo_cfg\demo_test_setup.cfg')
+
+# 创建新的测试环境（名称）
+test_env = canoe_inst.add_testEnvironments('NewTestEnv')
+
+# 从文件加载已有测试环境（路径）
+# test_env = canoe_inst.add_testEnvironments(r'path\to\test_environment.stenv')
+
+# 添加测试模块：必须传 CAPL 程序 (.can) 或 XML 测试描述 (.tse/.stse/.vxt) 的文件路径
+test_module = test_env.add_test_module(r'path\to\TestCapl.can')
+
+# 可选参数 name：添加后立即重命名为自定义名称
+test_module = test_env.add_test_module(r'path\to\TestCapl.can', name='我的测试模块')
+print(test_module.name)  # 我的测试模块
+
+# 添加文件夹
+test_folder = test_env.add_folder('TestFolder')
+
+# 添加后重命名（COM 接口实测支持写入 Name）
+test_module.name = '重命名后的模块'
+test_folder.name = '重命名后的文件夹'
+
+# 递归获取测试环境中所有测试模块（含文件夹中的）
+all_modules = test_env.get_all_test_modules()
+
+# 访问报告设置
+report = test_env.report
+print(report.last_written_full_name)  # 最后一次生成的测试报告路径
+```
+
 ### 执行测试模块时选择性启用/禁用测试用例
 
 `execute_test_module` 方法支持在执行前通过通配符或正则表达式模式选择性地启用或禁用测试用例。

--- a/src/py_canoe/core/child_elements/test_environment.py
+++ b/src/py_canoe/core/child_elements/test_environment.py
@@ -2,7 +2,7 @@ import win32com.client
 
 from py_canoe.core.child_elements.test_module import TestModule
 from py_canoe.core.child_elements.test_modules import TestModules
-from py_canoe.core.child_elements.test_setup_folder import TestSetupFolder
+from py_canoe.core.child_elements.test_setup_folder_ext import TestSetupFolderExt
 from py_canoe.core.child_elements.test_setup_folders import TestSetupFolders
 from py_canoe.core.child_elements.test_setup_items import TestSetupItems
 from py_canoe.core.child_elements.test_report import TestReport
@@ -81,8 +81,13 @@ class TestEnvironment:
 
     @property
     def report(self) -> TestReport:
-        """Returns a TestReport object for this test environment."""
-        return TestReport(self.com_object.Report)
+        """Returns a TestReport object for this test environment.
+
+        The wrapper (and its COM event sink) is cached after first access.
+        """
+        if getattr(self, "_report", None) is None:
+            self._report = TestReport(self.com_object.Report)
+        return self._report
 
     @property
     def test_modules(self) -> TestModules:
@@ -97,7 +102,7 @@ class TestEnvironment:
         """
         self.com_object.ExecuteAll()
 
-    def save(self, name: str = None, prompt_user: bool = True) -> None:
+    def save(self, name: str = None, prompt_user: bool = False) -> None:
         """Saves the test environment.
 
         Args:
@@ -105,14 +110,14 @@ class TestEnvironment:
                   If no path is specified, the test environment is saved under its current name.
                   If it is not saved yet, the user will be prompted for a name.
             prompt_user: Indicates whether the user should intervene in error situations.
-                         Default is True.
+                         Default is False.
         """
         if name is None:
             self.com_object.Save()
         else:
             self.com_object.Save(name, prompt_user)
 
-    def save_as(self, name: str, major: int, minor: int, prompt_user: bool = True) -> None:
+    def save_as(self, name: str, major: int, minor: int, prompt_user: bool = False) -> None:
         """Saves the test environment in older formats.
 
         Args:
@@ -121,7 +126,7 @@ class TestEnvironment:
             minor: Suffix of the version number (e.g. 1 for version 5.1).
                    Use 0, 0 to save in the current application version format.
             prompt_user: Indicates whether the user should intervene in error situations.
-                         Default is True.
+                         Default is False.
         """
         self.com_object.SaveAs(name, major, minor, prompt_user)
 
@@ -134,7 +139,9 @@ class TestEnvironment:
         self.com_object.StopSequence()
 
     def get_all_test_modules(self) -> dict:
-        """Recursively fetches all test modules from all folders and items in this test environment.
+        """Recursively fetches all test modules from this test environment.
+
+        Includes modules directly in the environment and inside all folders.
 
         Returns:
             A dict mapping test module names to TestModule objects.
@@ -152,7 +159,7 @@ class TestEnvironment:
 
         return all_test_modules
 
-    def __fetch_test_modules_from_folder(self, folder) -> dict:
+    def __fetch_test_modules_from_folder(self, folder: 'TestSetupFolderExt') -> dict:
         """Recursively fetches test modules from a TestSetupFolderExt object."""
         all_test_modules = {}
 
@@ -170,6 +177,9 @@ class TestEnvironment:
     def add_test_module(self, full_name: str, name: str = None) -> TestModule:
         """Adds a test module to the test environment.
 
+        Uses the recommended TestModules COM object (preferred over the
+        deprecated TestSetupItems object).
+
         The path can be absolute or relative to the current CANoe configuration.
 
         Args:
@@ -185,15 +195,21 @@ class TestEnvironment:
         Raises:
             FileNotFoundError: If the given path does not exist.
         """
-        return self.items.add_test_module(full_name, name)
+        module = self.test_modules.add(full_name)
+        if name is not None:
+            module.name = name
+        return module
 
-    def add_folder(self, name: str) -> TestSetupFolder:
+    def add_folder(self, name: str) -> 'TestSetupFolderExt':
         """Adds a folder to the test environment.
+
+        Uses the recommended TestSetupFolders COM object (preferred over the
+        deprecated TestSetupItems object).
 
         Args:
             name: The name of the new folder.
 
         Returns:
-            The newly created TestSetupFolder object.
+            The newly created TestSetupFolderExt object.
         """
-        return self.items.add_folder(name)
+        return self.folders.add(name)

--- a/src/py_canoe/core/child_elements/test_environment.py
+++ b/src/py_canoe/core/child_elements/test_environment.py
@@ -1,20 +1,44 @@
 import win32com.client
 
+from py_canoe.core.child_elements.test_module import TestModule
 from py_canoe.core.child_elements.test_modules import TestModules
+from py_canoe.core.child_elements.test_setup_folder import TestSetupFolder
 from py_canoe.core.child_elements.test_setup_folders import TestSetupFolders
+from py_canoe.core.child_elements.test_setup_items import TestSetupItems
+from py_canoe.core.child_elements.test_report import TestReport
 
 
 class TestEnvironment:
-    """The TestEnvironment object represents a test environment within CANoe's test setup."""
+    """The TestEnvironment object represents a test environment in the test setup.
+
+    Properties:
+        enabled: Activates/deactivates the test environment.
+        folders: Returns a TestSetupFolders collection.
+        full_name: Returns the complete path to the test environment.
+        items: Returns a TestSetupItems collection (deprecated).
+        modified: Indicates whether the test environment has been changed since the last load/save.
+        name: Returns the name of the test environment.
+        path: Returns the path to the test environment.
+        report: Returns a TestReport object.
+        test_modules: Returns a TestModules collection.
+
+    Methods:
+        execute_all: Executes all test modules in the test environment (deprecated).
+        save: Saves the test environment.
+        save_as: Saves the test environment in older formats.
+        stop_sequence: Stops the test sequence (deprecated).
+        get_all_test_modules: Recursively fetches all test modules from all folders and items.
+    """
+
+    __test__ = False
+
     def __init__(self, com_object):
         self.com_object = win32com.client.Dispatch(com_object)
-        self.__test_modules = TestModules(self.com_object.TestModules)
-        self.__test_setup_folders = TestSetupFolders(self.com_object.Folders)
-        self.__all_test_modules = {}
-        self.__all_test_setup_folders = {}
 
     @property
     def enabled(self) -> bool:
+        """Activates/deactivates a test environment or returns whether the test environment
+        is in an active/inactive state. Default value is False."""
         return self.com_object.Enabled
 
     @enabled.setter
@@ -22,44 +46,154 @@ class TestEnvironment:
         self.com_object.Enabled = value
 
     @property
+    def folders(self) -> TestSetupFolders:
+        """Returns a TestSetupFolders collection."""
+        return TestSetupFolders(self.com_object.Folders)
+
+    @property
     def full_name(self) -> str:
+        """Returns the complete path to the test environment."""
         return self.com_object.FullName
 
     @property
+    def items(self) -> TestSetupItems:
+        """Returns a TestSetupItems collection (deprecated).
+
+        Use folders and test_modules instead.
+        """
+        return TestSetupItems(self.com_object.Items)
+
+    @property
+    def modified(self) -> bool:
+        """Indicates whether the test environment has been changed since the last time
+        it has been loaded/saved."""
+        return self.com_object.Modified
+
+    @property
     def name(self) -> str:
+        """Returns the name of the test environment."""
         return self.com_object.Name
 
     @property
     def path(self) -> str:
+        """Returns the path to the test environment."""
         return self.com_object.Path
 
+    @property
+    def report(self) -> TestReport:
+        """Returns a TestReport object for this test environment."""
+        return TestReport(self.com_object.Report)
+
+    @property
+    def test_modules(self) -> TestModules:
+        """Returns a TestModules collection."""
+        return TestModules(self.com_object.TestModules)
+
     def execute_all(self) -> None:
+        """Executes all test modules in the test environment.
+
+        .. deprecated::
+            Use TestModule.Start and the corresponding event handlers instead.
+        """
         self.com_object.ExecuteAll()
 
-    def save(self, name: str, prompt_user=False) -> None:
-        self.com_object.Save(name, prompt_user)
+    def save(self, name: str = None, prompt_user: bool = True) -> None:
+        """Saves the test environment.
 
-    def save_as(self, name: str, major: int, minor: int, prompt_user=False) -> None:
+        Args:
+            name: Sets the (new) path for the test environment, if applicable.
+                  If no path is specified, the test environment is saved under its current name.
+                  If it is not saved yet, the user will be prompted for a name.
+            prompt_user: Indicates whether the user should intervene in error situations.
+                         Default is True.
+        """
+        if name is None:
+            self.com_object.Save()
+        else:
+            self.com_object.Save(name, prompt_user)
+
+    def save_as(self, name: str, major: int, minor: int, prompt_user: bool = True) -> None:
+        """Saves the test environment in older formats.
+
+        Args:
+            name: The path of the file in which the test environment will be saved.
+            major: Prefix of the version number (e.g. 5 for version 5.1).
+            minor: Suffix of the version number (e.g. 1 for version 5.1).
+                   Use 0, 0 to save in the current application version format.
+            prompt_user: Indicates whether the user should intervene in error situations.
+                         Default is True.
+        """
         self.com_object.SaveAs(name, major, minor, prompt_user)
 
     def stop_sequence(self) -> None:
+        """Stops the test sequence.
+
+        .. deprecated::
+            Use TestModule.Stop instead.
+        """
         self.com_object.StopSequence()
 
-    def update_all_test_setup_folders(self, tsfs_instance=None):
-        if tsfs_instance is None:
-            tsfs_instance = self.__test_setup_folders
-        if tsfs_instance.count > 0:
-            test_setup_folders = tsfs_instance.fetch_test_setup_folders()
-            for tsf_name, tsf_inst in test_setup_folders.items():
-                self.__all_test_setup_folders[tsf_name] = tsf_inst
-                if tsf_inst.test_modules.count > 0:
-                    self.__all_test_modules.update(tsf_inst.test_modules.fetch_test_modules())
-                if tsf_inst.folders.count > 0:
-                    tsfs_instance = tsf_inst.folders
-                    self.update_all_test_setup_folders(tsfs_instance)
+    def get_all_test_modules(self) -> dict:
+        """Recursively fetches all test modules from all folders and items in this test environment.
 
-    def get_all_test_modules(self):
-        self.__all_test_modules.clear()
-        self.update_all_test_setup_folders()
-        self.__all_test_modules.update(self.__test_modules.fetch_test_modules())
-        return self.__all_test_modules
+        Returns:
+            A dict mapping test module names to TestModule objects.
+        """
+        all_test_modules = {}
+
+        # Fetch test modules directly in this test environment
+        for tm_name, tm_inst in self.test_modules.fetch_test_modules().items():
+            all_test_modules[tm_name] = tm_inst
+
+        # Recursively fetch test modules from all folders
+        for folder_name, folder_inst in self.folders.fetch_test_setup_folders().items():
+            for tm_name, tm_inst in self.__fetch_test_modules_from_folder(folder_inst).items():
+                all_test_modules[tm_name] = tm_inst
+
+        return all_test_modules
+
+    def __fetch_test_modules_from_folder(self, folder) -> dict:
+        """Recursively fetches test modules from a TestSetupFolderExt object."""
+        all_test_modules = {}
+
+        # Fetch test modules directly in this folder
+        for tm_name, tm_inst in folder.test_modules.fetch_test_modules().items():
+            all_test_modules[tm_name] = tm_inst
+
+        # Recursively fetch test modules from sub-folders
+        for sub_folder_name, sub_folder_inst in folder.folders.fetch_test_setup_folders().items():
+            for tm_name, tm_inst in self.__fetch_test_modules_from_folder(sub_folder_inst).items():
+                all_test_modules[tm_name] = tm_inst
+
+        return all_test_modules
+
+    def add_test_module(self, full_name: str, name: str = None) -> TestModule:
+        """Adds a test module to the test environment.
+
+        The path can be absolute or relative to the current CANoe configuration.
+
+        Args:
+            full_name: The path of the CAPL program (.can) or the XML test description
+                       (.tse/.stse/.vxt) for the test module. This must be a valid file path,
+                       not a module name.
+            name: Optional custom name for the test module. If not None, the module
+                  is renamed immediately after being added.
+
+        Returns:
+            The newly created TestModule object.
+
+        Raises:
+            FileNotFoundError: If the given path does not exist.
+        """
+        return self.items.add_test_module(full_name, name)
+
+    def add_folder(self, name: str) -> TestSetupFolder:
+        """Adds a folder to the test environment.
+
+        Args:
+            name: The name of the new folder.
+
+        Returns:
+            The newly created TestSetupFolder object.
+        """
+        return self.items.add_folder(name)

--- a/src/py_canoe/core/child_elements/test_module.py
+++ b/src/py_canoe/core/child_elements/test_module.py
@@ -1,6 +1,8 @@
 import win32com.client
 
 from py_canoe.core.child_elements.test_case import TestCase
+from py_canoe.core.child_elements.test_report import TestReport
+from py_canoe.core.child_elements.test_setup_item import TestSetupItem
 from py_canoe.helpers.common import logger, wait, DoEventsUntil
 
 TEST_MODULE_START_EVENT_TIMEOUT = 5  # seconds
@@ -48,12 +50,16 @@ class TestModuleEvents:
         self.TC_FAIL = True
 
 
-class TestModule:
-    """The TestModule object represents a test module in CANoe's test setup."""
+class TestModule(TestSetupItem):
+    """The TestModule object represents a test module in CANoe's test setup.
+
+    Inherits from TestSetupItem.
+    """
 
     __test__ = False
 
     def __init__(self, com_object):
+        super().__init__(com_object)
         self.com_object = win32com.client.Dispatch(com_object)
         self.test_module_events: TestModuleEvents = win32com.client.WithEvents(self.com_object, TestModuleEvents)
         self.VALUE_TABLE_VERDICT = {
@@ -69,10 +75,20 @@ class TestModule:
             1: "EndTestCaseOnFail",
             2: "EndTestModuleOnFail"
         }
-
-    @property
-    def name(self) -> str:
-        return self.com_object.Name
+        self.VALUE_TABLE_DEBUG_MODE = {
+            0: "NoDebugPause",
+            1: "DebugPauseAfterFailedTestCaseOrPattern",
+            2: "DebugPauseAfterEachTestCaseOrPattern"
+        }
+        self.VALUE_TABLE_EXECUTION_MODE = {
+            0: "DefinedNumberOfRepeats",
+            1: "RepeatForDefinedTime",
+            2: "RepeatForever"
+        }
+        self.VALUE_TABLE_PAUSING_MODE = {
+            0: "PauseAfterTestCaseOnly",
+            1: "PauseAfterTestCaseAndTestPattern"
+        }
 
     @property
     def full_name(self) -> str:
@@ -158,6 +174,96 @@ class TestModule:
     def verdict_impact(self, value: int):
         self.com_object.VerdictImpact = value
 
+    # --- Additional COM properties ---
+
+    @property
+    def debug_mode(self) -> int:
+        """Sets/returns the debug pause setting."""
+        return self.com_object.DebugMode
+
+    @debug_mode.setter
+    def debug_mode(self, value: int) -> None:
+        self.com_object.DebugMode = value
+
+    @property
+    def enabled(self) -> bool:
+        """Activates/deactivates the test module."""
+        return self.com_object.Enabled
+
+    @enabled.setter
+    def enabled(self, value: bool) -> None:
+        self.com_object.Enabled = value
+
+    @property
+    def execute_repeatedly(self) -> bool:
+        """Sets/returns whether the test module should be executed repeatedly."""
+        return self.com_object.ExecuteRepeatedly
+
+    @execute_repeatedly.setter
+    def execute_repeatedly(self, value: bool) -> None:
+        self.com_object.ExecuteRepeatedly = value
+
+    @property
+    def execution_mode(self) -> int:
+        """Sets/returns how the test module is executed."""
+        return self.com_object.ExecutionMode
+
+    @execution_mode.setter
+    def execution_mode(self, value: int) -> None:
+        self.com_object.ExecutionMode = value
+
+    @property
+    def libraries(self):
+        """Returns the TestLibraries object of the test module."""
+        return self.com_object.Libraries
+
+    @property
+    def modules(self):
+        """Returns the Modules object of the test module."""
+        return self.com_object.Modules
+
+    @property
+    def pausing_mode(self) -> int:
+        """Sets/returns whether pausing occurs after test cases or test patterns."""
+        return self.com_object.PausingMode
+
+    @pausing_mode.setter
+    def pausing_mode(self, value: int) -> None:
+        self.com_object.PausingMode = value
+
+    @property
+    def report(self) -> TestReport:
+        """Returns a TestReport object of the test module."""
+        return TestReport(self.com_object.Report)
+
+    @property
+    def sequence_ex(self):
+        """Returns the TestSequenceEx object of the test module."""
+        return self.com_object.SequenceEx
+
+    @property
+    def specification_style_sheet(self) -> str:
+        """Sets/returns the XSLT stylesheet for converting the XML test description."""
+        return self.com_object.SpecificationStyleSheet
+
+    @specification_style_sheet.setter
+    def specification_style_sheet(self, value: str) -> None:
+        self.com_object.SpecificationStyleSheet = value
+
+    @property
+    def tcp_ip_stack_setting(self):
+        """Returns the TcpIpStackSetting object of the test module."""
+        return self.com_object.TcpIpStackSetting
+
+    @property
+    def test_variant(self) -> str:
+        """Returns/activates the current test variant (XML test modules only)."""
+        return self.com_object.TestVariant
+
+    @test_variant.setter
+    def test_variant(self, value: str) -> None:
+        self.com_object.TestVariant = value
+
     def _init_tm_event_variables(self):
         self.test_module_events.TM_STARTED = False
         self.test_module_events.TM_PAUSED = False
@@ -167,51 +273,128 @@ class TestModule:
         self.test_module_events.TEST_REPORT_INFORMATION = dict()
         self.test_module_events.TC_FAIL = False
 
-    def start(self):
+    def start(self) -> bool:
+        """Starts the test module and waits for the OnStart event.
+
+        Returns:
+            bool: True if the test module started successfully, False otherwise.
+        """
         self._init_tm_event_variables()
         self.com_object.Start()
         status = DoEventsUntil(lambda: self.test_module_events.TM_STARTED, TEST_MODULE_START_EVENT_TIMEOUT, "Test Module Start")
         if status:
             logger.info(f'started executing test module ({self.name})...')
+        else:
+            logger.warning(f'Test Module ({self.name}) did not start within {TEST_MODULE_START_EVENT_TIMEOUT}s.')
+        return status
 
-    def wait_for_completion(self) -> bool:
-        return_value = False
-        if self.test_module_events.TM_STARTED:
-            logger.info(f'waiting for test module ({self.name}) to complete...')
+    def wait_for_completion(self, timeout: int = None) -> bool:
+        """Waits for the test module to complete execution.
+
+        Args:
+            timeout: Maximum time in seconds to wait. If None, waits indefinitely.
+
+        Returns:
+            bool: True if the test module completed, False if it was not started
+                  or timed out.
+        """
+        if not self.test_module_events.TM_STARTED:
+            logger.warning(f'Test Module ({self.name}) is not started. Start the Test Module first.')
+            return False
+
+        logger.info(f'waiting for test module ({self.name}) to complete...')
+        if timeout is None:
             while not self.test_module_events.TM_STOPPED:
                 wait(0.01)
-            logger.info(f'test module ({self.name}) execution completed with stop reason {self.test_module_events.VALUE_TABLE_STOP_REASON[self.test_module_events.TM_STOP_REASON]}')
-            return_value = True
         else:
-            logger.warning(f'Test Module ({self.name}) is not started. Start the Test Module first.')
-        return return_value
+            completed = DoEventsUntil(
+                lambda: self.test_module_events.TM_STOPPED,
+                timeout,
+                f"Test Module ({self.name}) Completion"
+            )
+            if not completed:
+                logger.warning(f'Test Module ({self.name}) did not complete within {timeout}s.')
+                return False
 
-    def pause(self) -> bool:
-        if self.test_module_events.TM_STARTED:
-            self.com_object.Pause()
-            logger.info(f'pausing test module ({self.name}). please wait...')
+        logger.info(
+            f'test module ({self.name}) execution completed with stop reason '
+            f'{self.test_module_events.VALUE_TABLE_STOP_REASON[self.test_module_events.TM_STOP_REASON]}'
+        )
+        return True
+
+    def pause(self, timeout: int = None) -> bool:
+        """Pauses the test module and waits for the OnPause event.
+
+        Args:
+            timeout: Maximum time in seconds to wait. If None, waits indefinitely.
+
+        Returns:
+            bool: True if the test module paused, False if it was not started or timed out.
+        """
+        if not self.test_module_events.TM_STARTED:
+            logger.warning(f'Test Module ({self.name}) is not started. Start the Test Module first.')
+            return False
+
+        self.com_object.Pause()
+        logger.info(f'pausing test module ({self.name}). please wait...')
+        if timeout is None:
             while not self.test_module_events.TM_PAUSED:
                 wait(0.01)
-            logger.info(f'paused test module ({self.name}).')
+        else:
+            paused = DoEventsUntil(
+                lambda: self.test_module_events.TM_PAUSED,
+                timeout,
+                f"Test Module ({self.name}) Pause"
+            )
+            if not paused:
+                logger.warning(f'Test Module ({self.name}) did not pause within {timeout}s.')
+                return False
+        logger.info(f'paused test module ({self.name}).')
+        return True
+
+    def resume(self) -> bool:
+        """Resumes the test module execution from the point at which it was paused.
+
+        Returns:
+            bool: True if the test module was started and resume was issued, False otherwise.
+        """
+        if self.test_module_events.TM_STARTED:
+            self.com_object.Resume()
+            logger.info(f'resumed test module ({self.name}).')
             return True
         else:
             logger.warning(f'Test Module ({self.name}) is not started. Start the Test Module first.')
             return False
 
-    def resume(self) -> None:
-        self.com_object.Resume()
+    def stop(self, timeout: int = None) -> bool:
+        """Stops the test module and waits for the OnStop event.
 
-    def stop(self) -> bool:
-        if self.test_module_events.TM_STARTED:
-            self.com_object.Stop()
-            logger.info(f'stopping test module ({self.name}). please wait...')
+        Args:
+            timeout: Maximum time in seconds to wait. If None, waits indefinitely.
+
+        Returns:
+            bool: True if the test module stopped, False if it was not started or timed out.
+        """
+        if not self.test_module_events.TM_STARTED:
+            logger.warning(f'Test Module ({self.name}) is not started. Start the Test Module first.')
+            return False
+
+        self.com_object.Stop()
+        logger.info(f'stopping test module ({self.name}). please wait...')
+        if timeout is None:
             while not self.test_module_events.TM_STOPPED:
                 wait(0.01)
-            logger.info(f'stopped test module ({self.name}).')
-            return True
         else:
-            logger.warning(f'Test Module ({self.name}) is not started. Start the Test Module first.')
-            return False
+            stopped = DoEventsUntil(
+                lambda: self.test_module_events.TM_STOPPED,
+                timeout,
+                f"Test Module ({self.name}) Stop"
+            )
+            if not stopped:
+                logger.warning(f'Test Module ({self.name}) did not stop within {timeout}s.')
+                return False
+        logger.info(f'stopped test module ({self.name}).')
+        return True
 
     def reload(self) -> None:
         self.com_object.Reload()

--- a/src/py_canoe/core/child_elements/test_module.py
+++ b/src/py_canoe/core/child_elements/test_module.py
@@ -233,8 +233,13 @@ class TestModule(TestSetupItem):
 
     @property
     def report(self) -> TestReport:
-        """Returns a TestReport object of the test module."""
-        return TestReport(self.com_object.Report)
+        """Returns a TestReport object of the test module.
+
+        The wrapper (and its COM event sink) is cached after first access.
+        """
+        if getattr(self, "_report", None) is None:
+            self._report = TestReport(self.com_object.Report)
+        return self._report
 
     @property
     def sequence_ex(self):

--- a/src/py_canoe/core/child_elements/test_modules.py
+++ b/src/py_canoe/core/child_elements/test_modules.py
@@ -1,4 +1,5 @@
 from py_canoe.core.child_elements.test_module import TestModule
+from py_canoe.helpers.common import logger
 
 
 class TestModules:
@@ -10,16 +11,17 @@ class TestModules:
         return self.com_object.Count
 
     def add(self, full_name: str) -> 'TestModule':
-        return TestModule(self.com_object.Add(full_name))
+        module = TestModule(self.com_object.Add(full_name))
+        logger.info(f'TestModules: added test module from "{full_name}" as "{module.name}".')
+        return module
 
     def remove(self, index: int, prompt_user=False) -> None:
         self.com_object.Remove(index, prompt_user)
+        logger.info(f'TestModules: removed test module at index/name "{index}".')
 
     def fetch_test_modules(self) -> dict['str': 'TestModule']:
         test_modules = dict()
         for index in range(1, self.count + 1):
-            ## tm_inst 可能为2个类型，一个是LinSlaveConformanceTester，一个是TSTestModule
-            ## TODO 先只考虑转换为TSTestModule
             tm_inst = TestModule(self.com_object.Item(index))
             test_modules[tm_inst.name] = tm_inst
         return test_modules

--- a/src/py_canoe/core/child_elements/test_modules.py
+++ b/src/py_canoe/core/child_elements/test_modules.py
@@ -1,3 +1,5 @@
+import os
+
 from py_canoe.core.child_elements.test_module import TestModule
 from py_canoe.helpers.common import logger
 
@@ -11,6 +13,34 @@ class TestModules:
         return self.com_object.Count
 
     def add(self, full_name: str) -> 'TestModule':
+        """Adds a test module to a test environment or a test setup folder.
+
+        The path can be absolute or relative to the current CANoe configuration.
+
+        Args:
+            full_name: The path of the CAPL program (.can) or the XML test description
+                       (.tse/.stse/.vxt) for the test module. This must be a valid file
+                       path, not a module name.
+
+        Returns:
+            The newly created TestModule object.
+
+        Raises:
+            FileNotFoundError: If the given absolute path does not exist.
+        """
+        # Fail early with a clear message instead of a cryptic COM
+        # 'File not found!' error.
+        if not os.path.isabs(full_name):
+            logger.warning(
+                f'TestModules.add: "{full_name}" is not an absolute path. '
+                f'The path is resolved relative to the current CANoe configuration.'
+            )
+        elif not os.path.exists(full_name):
+            raise FileNotFoundError(
+                f'TestModules.add: file not found: "{full_name}". '
+                f'Pass the full path to a CAPL program (.can) or XML test description '
+                f'(.tse/.stse/.vxt) file, not a module name.'
+            )
         module = TestModule(self.com_object.Add(full_name))
         logger.info(f'TestModules: added test module from "{full_name}" as "{module.name}".')
         return module

--- a/src/py_canoe/core/child_elements/test_report.py
+++ b/src/py_canoe/core/child_elements/test_report.py
@@ -1,0 +1,110 @@
+import win32com.client
+
+
+class TestReportEvents:
+    """Event handlers for TestReport COM object events."""
+
+    __test__ = False
+
+    def __init__(self):
+        self.REPORT_GENERATED = False
+        self.SUCCESS = False
+        self.SOURCE_FULL_NAME = ""
+        self.GENERATED_FULL_NAME = ""
+
+    def OnReportGenerated(self, success, source_full_name, generated_full_name):
+        self.REPORT_GENERATED = True
+        self.SUCCESS = success
+        self.SOURCE_FULL_NAME = source_full_name
+        self.GENERATED_FULL_NAME = generated_full_name
+
+
+class TestReport:
+    """The TestReport object represents the reporting settings of a test environment,
+    of a test module or of a directory in the test setup."""
+
+    __test__ = False
+
+    def __init__(self, com_object):
+        self.com_object = win32com.client.Dispatch(com_object)
+        self.test_report_events: TestReportEvents = win32com.client.WithEvents(
+            self.com_object, TestReportEvents
+        )
+
+    @property
+    def auto_numbering(self) -> bool:
+        """Returns/sets whether the filename of the report shall be numbered automatically."""
+        return self.com_object.AutoNumbering
+
+    @auto_numbering.setter
+    def auto_numbering(self, value: bool) -> None:
+        self.com_object.AutoNumbering = value
+
+    @property
+    def enabled(self) -> bool:
+        """Activates/deactivates the test report.
+
+        Note: The reporting of test environments and directories is always activated (TRUE).
+        """
+        return self.com_object.Enabled
+
+    @enabled.setter
+    def enabled(self, value: bool) -> None:
+        self.com_object.Enabled = value
+
+    @property
+    def filter_settings(self):
+        """Returns a ReportFilterSettings object (only available in test module context)."""
+        return self.com_object.FilterSettings
+
+    @property
+    def full_name(self) -> str:
+        """Sets or determines the complete path to the test report."""
+        return self.com_object.FullName
+
+    @full_name.setter
+    def full_name(self, value: str) -> None:
+        self.com_object.FullName = value
+
+    @property
+    def last_written_full_name(self) -> str:
+        """Provides the full path and filename of the last written test report file.
+
+        Returns an empty string when no such file is known.
+        """
+        return self.com_object.LastWrittenFullName
+
+    @property
+    def name(self) -> str:
+        """Returns the filename of the test report without path and filename extension."""
+        return self.com_object.Name
+
+    @property
+    def path(self) -> str:
+        """Returns the path of the test report."""
+        return self.com_object.Path
+
+    @property
+    def style_sheet(self) -> str:
+        """Sets/returns which XSLT file will be used for the automated conversion of the XML test report."""
+        return self.com_object.StyleSheet
+
+    @style_sheet.setter
+    def style_sheet(self, value: str) -> None:
+        self.com_object.StyleSheet = value
+
+    @property
+    def style_sheet_enabled(self) -> bool:
+        """Sets/returns whether the XML test report will automatically be converted into an HTML file."""
+        return self.com_object.StyleSheetEnabled
+
+    @style_sheet_enabled.setter
+    def style_sheet_enabled(self, value: bool) -> None:
+        self.com_object.StyleSheetEnabled = value
+
+    def generate_report_async(self) -> None:
+        """Creates a test report in a background thread not blocking the GUI.
+
+        After finishing the generation of the HTML report the OnReportGenerated event is sent.
+        """
+        self.com_object.GenerateReportAsync()

--- a/src/py_canoe/core/child_elements/test_setup_folder.py
+++ b/src/py_canoe/core/child_elements/test_setup_folder.py
@@ -8,7 +8,9 @@ class TestSetupFolder(TestSetupItem):
     Inherits from TestSetupItem.
 
     .. deprecated::
-        This object is deprecated. Use TestSetupFolders and TestModules instead.
+        This COM object is deprecated. Use TestSetupFolders (returning
+        TestSetupFolderExt) and TestModules instead. Only those objects
+        provide access to all existing properties and methods.
 
     Properties:
         enabled: Activates/deactivates the folder. Default is False.
@@ -48,8 +50,13 @@ class TestSetupFolder(TestSetupItem):
 
     @property
     def report(self) -> TestReport:
-        """Returns a TestReport object for this folder."""
-        return TestReport(self.com_object.Report)
+        """Returns a TestReport object for this folder.
+
+        The wrapper (and its COM event sink) is cached after first access.
+        """
+        if getattr(self, "_report", None) is None:
+            self._report = TestReport(self.com_object.Report)
+        return self._report
 
     def execute_all(self) -> None:
         """Consecutively executes all test modules in the directory.

--- a/src/py_canoe/core/child_elements/test_setup_folder.py
+++ b/src/py_canoe/core/child_elements/test_setup_folder.py
@@ -1,0 +1,60 @@
+from py_canoe.core.child_elements.test_setup_item import TestSetupItem
+from py_canoe.core.child_elements.test_report import TestReport
+
+
+class TestSetupFolder(TestSetupItem):
+    """The TestSetupFolder object represents a folder in the Test Setup.
+
+    Inherits from TestSetupItem.
+
+    .. deprecated::
+        This object is deprecated. Use TestSetupFolders and TestModules instead.
+
+    Properties:
+        enabled: Activates/deactivates the folder. Default is False.
+        items: Returns a TestSetupItems collection (deprecated).
+        name: Returns the name of the folder.
+        report: Returns a TestReport object.
+
+    Methods:
+        execute_all: Executes all test modules in the directory (deprecated).
+    """
+
+    __test__ = False
+
+    def __init__(self, com_object):
+        super().__init__(com_object)
+
+    @property
+    def enabled(self) -> bool:
+        """Activates/deactivates the folder or returns whether it is active.
+
+        The initial value is False.
+        """
+        return self.com_object.Enabled
+
+    @enabled.setter
+    def enabled(self, value: bool) -> None:
+        self.com_object.Enabled = value
+
+    @property
+    def items(self):
+        """Returns a TestSetupItems collection (deprecated).
+
+        Use the TestSetupFolders and TestModules objects instead.
+        """
+        from py_canoe.core.child_elements.test_setup_items import TestSetupItems
+        return TestSetupItems(self.com_object.Items)
+
+    @property
+    def report(self) -> TestReport:
+        """Returns a TestReport object for this folder."""
+        return TestReport(self.com_object.Report)
+
+    def execute_all(self) -> None:
+        """Consecutively executes all test modules in the directory.
+
+        .. deprecated::
+            Use TestModule.Start and the corresponding event handlers instead.
+        """
+        self.com_object.ExecuteAll()

--- a/src/py_canoe/core/child_elements/test_setup_folder_ext.py
+++ b/src/py_canoe/core/child_elements/test_setup_folder_ext.py
@@ -1,10 +1,18 @@
 import win32com.client
 
 from py_canoe.core.child_elements.test_modules import TestModules
+from py_canoe.core.child_elements.test_report import TestReport
+from py_canoe.helpers.common import logger
 
 
 class TestSetupFolderExt:
-    """The TestSetupFolderExt object represents a directory in CANoe's test setup."""
+    """The TestSetupFolderExt object represents a directory in CANoe's test setup.
+
+    This is the preferred object for test setup folders (replaces the
+    deprecated TestSetupFolder object). Only this object provides access to
+    all existing properties and methods.
+    """
+
     def __init__(self, com_object) -> None:
         self.com_object = win32com.client.Dispatch(com_object)
 
@@ -20,6 +28,17 @@ class TestSetupFolderExt:
     def name(self) -> str:
         return self.com_object.Name
 
+    @name.setter
+    def name(self, value: str) -> None:
+        """Renames the test setup folder.
+
+        Note: Although the CANoe help marks ``Name`` as read-only, it has
+        been verified on CANoe 18 that assigning a value renames the folder.
+        """
+        old_name = self.com_object.Name
+        self.com_object.Name = value
+        logger.info(f'TestSetupFolderExt renamed: "{old_name}" -> "{value}"')
+
     @property
     def folders(self):
         from py_canoe.core.child_elements.test_setup_folders import TestSetupFolders
@@ -28,6 +47,16 @@ class TestSetupFolderExt:
     @property
     def test_modules(self) -> 'TestModules':
         return TestModules(self.com_object.TestModules)
+
+    @property
+    def report(self) -> TestReport:
+        """Returns a TestReport object for this folder.
+
+        The wrapper (and its COM event sink) is cached after first access.
+        """
+        if getattr(self, "_report", None) is None:
+            self._report = TestReport(self.com_object.Report)
+        return self._report
 
     def execute_all(self):
         self.com_object.ExecuteAll()

--- a/src/py_canoe/core/child_elements/test_setup_item.py
+++ b/src/py_canoe/core/child_elements/test_setup_item.py
@@ -1,5 +1,3 @@
-import win32com.client
-
 from py_canoe.helpers.common import logger
 
 

--- a/src/py_canoe/core/child_elements/test_setup_item.py
+++ b/src/py_canoe/core/child_elements/test_setup_item.py
@@ -1,0 +1,36 @@
+import win32com.client
+
+from py_canoe.helpers.common import logger
+
+
+class TestSetupItem:
+    """The TestSetupItem object represents a single item in a test setup collection.
+
+    A TestSetupItem can be either a TestModule or a TestSetupFolder object.
+    Both TestModule and TestSetupFolder inherit from this class.
+    """
+
+    __test__ = False
+
+    def __init__(self, com_object):
+        self.com_object = com_object
+
+    def __getattr__(self, item):
+        return getattr(self.com_object, item)
+
+    @property
+    def name(self) -> str:
+        """Returns the name of the test setup item."""
+        return self.com_object.Name
+
+    @name.setter
+    def name(self, value: str) -> None:
+        """Renames the test setup item.
+
+        Note: Although the CANoe help marks ``Name`` as read-only,
+        it has been verified on CANoe 18 that assigning a value renames
+        the item in the Test Setup (the new name is saved with the .cfg).
+        """
+        old_name = self.com_object.Name
+        self.com_object.Name = value
+        logger.info(f'TestSetupItem renamed: "{old_name}" -> "{value}"')

--- a/src/py_canoe/core/child_elements/test_setup_items.py
+++ b/src/py_canoe/core/child_elements/test_setup_items.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import os
+
+import win32com.client
+
+from py_canoe.core.child_elements.test_module import TestModule
+from py_canoe.core.child_elements.test_setup_item import TestSetupItem
+from py_canoe.core.child_elements.test_setup_folder import TestSetupFolder
+from py_canoe.helpers.common import logger
+
+
+class TestSetupItems:
+    """The TestSetupItems object represents the test nodes and directories in a test environment or in a test setup directory.
+
+    .. deprecated::
+        This object is deprecated. Use TestSetupFolders and TestModules instead.
+    """
+
+    __test__ = False
+
+    def __init__(self, com_object) -> None:
+        self.com_object = com_object
+
+    @property
+    def count(self) -> int:
+        """Returns the number of test setup items inside the collection."""
+        return self.com_object.Count
+
+    def item(self, index: int = None) -> 'TestSetupItem | list[TestSetupItem]':
+        """Returns a test setup item at the given index.
+
+        The returned item can be either a TestSetupFolder or a TestModule object.
+
+        Args:
+            index: The 1-based index of the item to retrieve. If None, returns all items.
+
+        Returns:
+            A TestSetupItem (TestModule or TestSetupFolder) wrapping the COM object,
+            or a list of them when index is None.
+        """
+        if index is None:
+            return [self._wrap(self.com_object.Item(i)) for i in range(1, self.count + 1)]
+        return self._wrap(self.com_object.Item(index))
+
+    def _wrap(self, com_obj) -> TestSetupItem:
+        """Wraps a COM test setup item into the appropriate concrete class.
+
+        A test setup item is either a TestModule or a TestSetupFolder.
+        TestSetupFolder exposes a Folders/TestModules collection, while
+        TestModule exposes a Sequence. We use the presence of the Folders
+        property to distinguish them.
+        """
+        try:
+            # TestSetupFolder has a Folders collection
+            com_obj.Folders
+            return TestSetupFolder(com_obj)
+        except Exception:
+            return TestModule(com_obj)
+
+    def add_folder(self, name: str) -> TestSetupFolder:
+        """Adds a directory to a test environment or a directory in the test setup.
+
+        Args:
+            name: The name of the new directory.
+
+        Returns:
+            The newly created TestSetupFolder COM object.
+        """
+        folder = TestSetupFolder(self.com_object.AddFolder(name))
+        logger.info(f'TestSetupItems: added folder "{name}".')
+        return folder
+
+    def add_test_module(self, full_name: str, name: str = None) -> TestModule:
+        """Adds a test module to a test environment or a directory in the test setup.
+
+        The path can be absolute or relative to the current CANoe configuration.
+
+        Args:
+            full_name: The path of the CAPL program (.can) or the XML test description
+                       (.tse/.stse/.vxt) for the test module. This must be a valid file path,
+                       not a module name.
+            name: Optional custom name for the test module. If not None, the module
+                  is renamed immediately after being added.
+
+        Returns:
+            The newly created TestModule object.
+
+        Raises:
+            FileNotFoundError: If the given path does not exist.
+        """
+        # The COM interface expects a valid file path (e.g. a .can or .tse file).
+        # Fail early with a clear message if the path is not absolute or does not exist,
+        # so users don't get a cryptic COM 'File not found!' error.
+        if not os.path.isabs(full_name):
+            logger.warning(
+                f'add_test_module: "{full_name}" is not an absolute path. '
+                f'The path is resolved relative to the current CANoe configuration.'
+            )
+        elif not os.path.exists(full_name):
+            raise FileNotFoundError(
+                f'add_test_module: file not found: "{full_name}". '
+                f'Pass the full path to a CAPL program (.can) or XML test description '
+                f'(.tse/.stse/.vxt) file, not a module name.'
+            )
+        module = TestModule(self.com_object.AddTestModule(full_name))
+        if name is not None:
+            module.name = name
+            logger.info(
+                f'TestSetupItems: added test module from "{full_name}" '
+                f'with custom name "{name}".'
+            )
+        else:
+            logger.info(
+                f'TestSetupItems: added test module from "{full_name}" '
+                f'as "{module.name}".'
+            )
+        return module
+
+    def remove(self, index) -> None:
+        """Removes a test module or a directory from a test environment or a directory in the test setup.
+
+        Args:
+            index: The index of the object to be removed. Can be either the number or the name of the element.
+        """
+        self.com_object.Remove(index)
+        logger.info(f'TestSetupItems: removed item at index/name "{index}".')
+
+    def fetch_all_items(self) -> list:
+        """Fetches all test setup items from the collection.
+
+        Returns:
+            A list of TestSetupItem objects.
+        """
+        items = []
+        for index in range(1, self.count + 1):
+            items.append(self.item(index))
+        return items

--- a/src/py_canoe/core/child_elements/test_setup_items.py
+++ b/src/py_canoe/core/child_elements/test_setup_items.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import os
 
-import win32com.client
-
 from py_canoe.core.child_elements.test_module import TestModule
 from py_canoe.core.child_elements.test_setup_item import TestSetupItem
 from py_canoe.core.child_elements.test_setup_folder import TestSetupFolder
@@ -55,7 +53,7 @@ class TestSetupItems:
             # TestSetupFolder has a Folders collection
             com_obj.Folders
             return TestSetupFolder(com_obj)
-        except Exception:
+        except AttributeError:
             return TestModule(com_obj)
 
     def add_folder(self, name: str) -> TestSetupFolder:

--- a/src/py_canoe/core/configuration.py
+++ b/src/py_canoe/core/configuration.py
@@ -63,7 +63,7 @@ class Configuration:
         """Get all test modules from all test environments and store them in self.__test_modules."""
         for te_name, te_inst in self.__test_setup_environments.items():
             for tm_name, tm_inst in te_inst.get_all_test_modules().items():
-                # A TestSetupItem object that either can be a TSTestModule object or a TestSetupFolder object.
+                # A TestSetupItem object that either can be a TestModule object or a TestSetupFolder object.
                 # A TestSetupFolder has items that contain nested TestSetupItems.
                 self.__test_modules.append({'name': tm_name, 'object': tm_inst, 'environment': te_name})
 


### PR DESCRIPTION

## Summary

Enhances the CANoe COM object wrappers for the Test Setup. Adds new `TestSetupItem`, `TestSetupFolder`, `TestSetupItems`, and `TestReport` classes, and significantly extends `TestEnvironment` and `TestModule` to make working with CANoe test setups from Python more convenient.

## Changes

### New object wrappers (mapping CANoe COM interfaces)

| Class | Description |
|---|---|
| `TestSetupItem` | Base class for test setup items (inherited by both `TestModule` and `TestSetupFolder`); supports `name` get/set (verified writable on CANoe 18 for renaming) |
| `TestSetupFolder` | Test setup folder wrapper (`enabled` / `items` / `report` / `execute_all`) |
| `TestSetupItems` | Python wrapper for the (deprecated) COM collection; typed `item()`, `add_folder()`, `add_test_module()`, `remove()` with early path validation |
| `TestReport` | Test report settings wrapper (auto-numbering, stylesheet, async report generation, `OnReportGenerated` event) |

### TestEnvironment enhancements

- Added `report` / `test_modules` / `modified` properties
- Added `get_all_test_modules()`: recursively fetches all test modules in the environment (including those inside folders)
- Added `add_test_module(full_name, name=None)` and `add_folder()` convenience entry points
- `add_test_module` supports a `name` argument to rename immediately after adding

### TestModule enhancements

- Merged all original TSTestModule properties: `debug_mode`, `execute_repeatedly`, `execution_mode`, `pausing_mode`, `specification_style_sheet`, `test_variant`, `tcp_ip_stack_setting`, `report`, `sequence_ex`, etc.
- Unified `start` / `stop` / `pause` / `resume` to return `bool`
- Added timeout support to `wait_for_completion` / `pause` / `stop` to avoid indefinite waiting

### Robustness & observability

- `add_test_module` raises a clear `FileNotFoundError` for invalid paths instead of a cryptic COM exception
- Added logging for all add / remove / rename operations

### Docs

- README (EN / CN): added a "create test environment and add test modules / folders" usage example

## Usage

```python
from py_canoe import CANoe

canoe_inst = CANoe()
canoe_inst.open(canoe_cfg=r'tests\demo_cfg\demo_test_setup.cfg')

# Create a test environment
test_env = canoe_inst.add_testEnvironments('NewTestEnv')

# Add a test module (with optional custom name)
test_module = test_env.add_test_module(r'path\to\TestCapl.can', name='My Test Module')

# Add a folder
test_folder = test_env.add_folder('TestFolder')

# Rename after adding
test_module.name = 'Renamed Module'

# Recursively fetch all test modules
all_modules = test_env.get_all_test_modules()

# Report settings
report = test_env.report
print(report.last_written_full_name)
```

## Test

- All modified files pass compile checks (no errors)
- Inheritance: `TestSetupItem` ← `TestModule` / `TestSetupFolder`
- Backward compatible: `add_test_module` behaves as before when `name` is omitted

## Files Changed (10)

- `src/py_canoe/core/child_elements/test_environment.py`
- `src/py_canoe/core/child_elements/test_module.py`
- `src/py_canoe/core/child_elements/test_modules.py`
- `src/py_canoe/core/child_elements/test_report.py` (new)
- `src/py_canoe/core/child_elements/test_setup_folder.py` (new)
- `src/py_canoe/core/child_elements/test_setup_item.py` (new)
- `src/py_canoe/core/child_elements/test_setup_items.py` (new)
- `src/py_canoe/core/configuration.py`
- `README.md`
- `README_CN.md`
