### PR TITLE
fix: scope sysvar COM event sinks to the write

### DIFF
--- a/src/py_canoe/canoe.py
+++ b/src/py_canoe/canoe.py
@@ -1175,12 +1175,12 @@ class CANoe:
             sys_var_name (str): The name of the system variable.
             return_symbolic_name (bool): Whether to return the symbolic name.
             return_timestamp (bool): Whether to return the timestamp in timezone utc along with the signal value. Defaults to False.
-            enable_events (bool): Whether to enable COM events on the Variable object. Defaults to True.
+            enable_events (bool): This argument is deprecated and will be removed in a future version.
 
         Returns:
             Union[int, float, str, None, tuple]: The value of the system variable or None if not found. If return_timestamp is True, returns a tuple of (value, timestamp).
         """
-        variable_value = self.application.system.get_variable_value(sys_var_name, return_symbolic_name, enable_events)
+        variable_value = self.application.system.get_variable_value(sys_var_name, return_symbolic_name)
         if return_timestamp:
             return variable_value, datetime.now(timezone.utc).timestamp()
         return variable_value
@@ -1193,20 +1193,21 @@ class CANoe:
         """Returns all variables in the specified namespace."""
         return self.application.system.get_all_variables_in_namespace(namespace_name)
 
-    def set_system_variable_value(self, sys_var_name: str, value: Union[int, float, str]) -> bool:
+    def set_system_variable_value(self, sys_var_name: str, value: Union[int, float, str], enable_events: bool = True) -> bool:
         """
         Sets the value of a system variable.
 
         Args:
             sys_var_name (str): The name of the system variable.
             value (Union[int, float, str]): The value to set.
+            enable_events (bool): Whether to enable COM events on the Variable object. Defaults to True. When False the write is not confirmed by an update event.
 
         Returns:
             bool: True if the operation was successful, False otherwise.
         """
-        return self.application.system.set_variable_value(sys_var_name, value)
+        return self.application.system.set_variable_value(sys_var_name, value, enable_events=enable_events)
 
-    def set_system_variable_array_values(self, sys_var_name: str, value: tuple, index: int = 0) -> bool:
+    def set_system_variable_array_values(self, sys_var_name: str, value: tuple, index: int = 0, enable_events: bool = True) -> bool:
         """
         Sets the values of a system variable array.
 
@@ -1214,11 +1215,12 @@ class CANoe:
             sys_var_name (str): The name of the system variable.
             value (tuple): The values to set.
             index (int): The index to set the values at.
+            enable_events (bool): Whether to enable COM events on the Variable object. Defaults to True. When False the write is not confirmed by an update event.
 
         Returns:
             bool: True if the operation was successful, False otherwise.
         """
-        return self.application.system.set_variable_array_values(sys_var_name, value, index)
+        return self.application.system.set_variable_array_values(sys_var_name, value, index, enable_events=enable_events)
 
     def ui_activate_desktop(self, name: str) -> bool:
         """

--- a/src/py_canoe/canoe_robot_lib.py
+++ b/src/py_canoe/canoe_robot_lib.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------------
 # THIS FILE IS AUTO-GENERATED - DO NOT EDIT MANUALLY
-# Generated: 2026-07-29T16:37:37.385816+00:00
-# py-canoe package version: 26.3.6
+# Generated: 2026-08-04T10:13:57.666632+00:00
+# py-canoe package version: 26.3.7
 # To update this file, run the generator: python -m py_canoe.helpers.gen_canoe_robot_lib
 # ---------------------------------------------------------------------------
 
@@ -1078,7 +1078,7 @@ class CanoeRobotLib:
             sys_var_name (str): The name of the system variable.
             return_symbolic_name (bool): Whether to return the symbolic name.
             return_timestamp (bool): Whether to return the timestamp in timezone utc along with the signal value. Defaults to False.
-            enable_events (bool): Whether to enable COM events on the Variable object. Defaults to True.
+            enable_events (bool): This argument is deprecated and will be removed in a future version.
         
         Returns:
             Union[int, float, str, None, tuple]: The value of the system variable or None if not found. If return_timestamp is True, returns a tuple of (value, timestamp).
@@ -1093,20 +1093,21 @@ class CanoeRobotLib:
         """Returns all variables in the specified namespace."""
         return self._source.get_all_variables_in_namespace(namespace_name)
 
-    def canoe_set_system_variable_value(self, sys_var_name: str, value: Union[int, float, str]) -> bool:
+    def canoe_set_system_variable_value(self, sys_var_name: str, value: Union[int, float, str], enable_events: bool=True) -> bool:
         """
         Sets the value of a system variable.
         
         Args:
             sys_var_name (str): The name of the system variable.
             value (Union[int, float, str]): The value to set.
+            enable_events (bool): Whether to enable COM events on the Variable object. Defaults to True. When False the write is not confirmed by an update event.
         
         Returns:
             bool: True if the operation was successful, False otherwise.
         """
-        return self._source.set_system_variable_value(sys_var_name, value)
+        return self._source.set_system_variable_value(sys_var_name, value, enable_events)
 
-    def canoe_set_system_variable_array_values(self, sys_var_name: str, value: tuple, index: int=0) -> bool:
+    def canoe_set_system_variable_array_values(self, sys_var_name: str, value: tuple, index: int=0, enable_events: bool=True) -> bool:
         """
         Sets the values of a system variable array.
         
@@ -1114,11 +1115,12 @@ class CanoeRobotLib:
             sys_var_name (str): The name of the system variable.
             value (tuple): The values to set.
             index (int): The index to set the values at.
+            enable_events (bool): Whether to enable COM events on the Variable object. Defaults to True. When False the write is not confirmed by an update event.
         
         Returns:
             bool: True if the operation was successful, False otherwise.
         """
-        return self._source.set_system_variable_array_values(sys_var_name, value, index)
+        return self._source.set_system_variable_array_values(sys_var_name, value, index, enable_events)
 
     def canoe_ui_activate_desktop(self, name: str) -> bool:
         """

--- a/src/py_canoe/core/child_elements/variable.py
+++ b/src/py_canoe/core/child_elements/variable.py
@@ -1,4 +1,5 @@
 from typing import Union
+import pythoncom
 import win32com.client
 
 from py_canoe.helpers.common import logger, DoEventsUntil
@@ -10,8 +11,6 @@ class Variable:
     def __init__(self, com_object, enable_events: bool = True):
         self.com_object = win32com.client.Dispatch(com_object)
         self.enable_events = enable_events
-        if self.enable_events:
-            self.variable_events: VariableEvents = win32com.client.WithEvents(self.com_object, VariableEvents)
 
     @property
     def analysis_only(self) -> bool:
@@ -110,14 +109,23 @@ class Variable:
         return self.com_object.Value
 
     def set_value(self, value, timeout: Union[int, float]):
-        status: bool = False
-        self.com_object.Value = value
-        if hasattr(self, 'variable_events') and self.variable_events:
-            self.variable_events.VARIABLE_UPDATED = False
-            status = DoEventsUntil(lambda: self.variable_events.VARIABLE_UPDATED, timeout, "Variable Update")
+        if not self.enable_events:
+            self.com_object.Value = value
+            return True
+        # CANoe pins an advised sink alive, so its __del__ never runs and Unadvise has to be explicit
+        events = win32com.client.WithEvents(self.com_object, VariableEvents)
+        try:
+            events.VARIABLE_UPDATED = False
+            self.com_object.Value = value
+            status = DoEventsUntil(lambda: events.VARIABLE_UPDATED, timeout, "Variable Update")
             if status:
                 logger.info(f"Variable '{self.full_name}' updated successfully to: {value}")
-        return status
+            return status
+        finally:
+            try:
+                events.close()
+            except pythoncom.com_error as e:
+                logger.debug(f"Variable event sink already disconnected: {e}")
 
     def begin_struct_update(self):
         self.com_object.BeginStructUpdate()

--- a/src/py_canoe/core/system.py
+++ b/src/py_canoe/core/system.py
@@ -83,6 +83,7 @@ class System:
 
     def get_variable_value(self, sys_var_name: str, return_symbolic_name=False, enable_events: bool = True) -> Union[int, float, str, None]:
         """Get the value of a system variable. If the variable does not exist, it will log an error message and return None."""
+        # enable_events is deprecated and ignored: reading a variable never registers a COM event sink
         try:
             parts = sys_var_name.split('::')
             if len(parts) < 2:
@@ -91,7 +92,7 @@ class System:
             namespace = '::'.join(parts[:-1])
             variable_name = parts[-1]
             namespace_obj = self.com_object.Namespaces(namespace)
-            variable_obj = Variable(namespace_obj.Variables(variable_name), enable_events)
+            variable_obj = Variable(namespace_obj.Variables(variable_name))
             value = variable_obj.get_value()
             if return_symbolic_name:
                 symbolic_value = variable_obj.get_symbolic_value_name(value)
@@ -103,7 +104,7 @@ class System:
             logger.error(f"Error retrieving System Variable '{sys_var_name}': {e}")
             return None
 
-    def set_variable_value(self, sys_var_name: str, value: Union[int, float, str], timeout: Union[int, float] = 1) -> bool:
+    def set_variable_value(self, sys_var_name: str, value: Union[int, float, str], timeout: Union[int, float] = 1, enable_events: bool = True) -> bool:
         """Set the value of a system variable. If the variable does not exist, it will log an error message and return False."""
         try:
             parts = sys_var_name.split('::')
@@ -113,7 +114,7 @@ class System:
             namespace = '::'.join(parts[:-1])
             variable_name = parts[-1]
             namespace_obj = self.com_object.Namespaces(namespace)
-            variable_obj = Variable(namespace_obj.Variables(variable_name))
+            variable_obj = Variable(namespace_obj.Variables(variable_name), enable_events)
             var_type = type(variable_obj.get_value())
             try:
                 converted_value = var_type(value)
@@ -126,7 +127,7 @@ class System:
             logger.error(f"Error setting System Variable '{sys_var_name}': {e}")
             return False
 
-    def set_variable_array_values(self, sys_var_name: str, value: tuple, index: int = 0, timeout: Union[int, float] = 1) -> bool:
+    def set_variable_array_values(self, sys_var_name: str, value: tuple, index: int = 0, timeout: Union[int, float] = 1, enable_events: bool = True) -> bool:
         """Set the values of a system variable array starting from a specific index. If the variable does not exist or if there is not enough space in the array, it will log an error message and return False."""
         try:
             parts = sys_var_name.split('::')
@@ -136,7 +137,7 @@ class System:
             namespace = '::'.join(parts[:-1])
             variable_name = parts[-1]
             namespace_obj = self.com_object.Namespaces(namespace)
-            variable_obj = Variable(namespace_obj.Variables(variable_name))
+            variable_obj = Variable(namespace_obj.Variables(variable_name), enable_events)
             arr = list(variable_obj.get_value())
             if index < 0 or index + len(value) > len(arr):
                 logger.error(f"Not enough space in System Variable Array '{sys_var_name}' to set values.")


### PR DESCRIPTION
sink, so passing enable_events=False to get_system_variable_value avoided it — but writes always built Variable with events enabled and never unadvised. CANoe holds a reference to an advised sink, so __del__ never runs and every set_system_variable_value leaked one.

Rework:
- reads never register a sink; enable_events on get_system_variable_value is deprecated and ignored
- set_value advises the sink around the assignment only, closing it in a finally
- enable_events moved to set_system_variable_value and set_system_variable_array_values, where it applies