### PR TITLE
fix: clear corrupted gen_py modules before falling back to Dispatch

### DIFF
--- a/src/py_canoe/core/application.py
+++ b/src/py_canoe/core/application.py
@@ -201,7 +201,7 @@ class Application:
                 self.com_object = gencache.EnsureDispatch(self.CANOE_APP_NAME)
             except AttributeError:
                 logger.warning("gencache encountered a cache error. After clearing the corrupted gen_py module, revert to using Dispatch.")
-                # 清除 sys.modules 中损坏的 gen_py 缓存模块，防止 Dispatch 再次命中损坏缓存
+                # Clear corrupted gen_py cache modules from sys.modules to prevent Dispatch from reusing stale modules
                 for key in list(sys.modules.keys()):
                     if 'win32com.gen_py' in key:
                         del sys.modules[key]

--- a/src/py_canoe/core/application.py
+++ b/src/py_canoe/core/application.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import sys
 from typing import Any, Union
 import win32com
 import win32com.client
@@ -199,7 +200,11 @@ class Application:
             try:
                 self.com_object = gencache.EnsureDispatch(self.CANOE_APP_NAME)
             except AttributeError:
-                logger.warning("gencache cache error, fallback using Dispatch (no type hint)")
+                logger.warning("gencache encountered a cache error. After clearing the corrupted gen_py module, revert to using Dispatch.")
+                # 清除 sys.modules 中损坏的 gen_py 缓存模块，防止 Dispatch 再次命中损坏缓存
+                for key in list(sys.modules.keys()):
+                    if 'win32com.gen_py' in key:
+                        del sys.modules[key]
                 self.com_object = win32com.client.Dispatch(self.CANOE_APP_NAME)
             if self._enable_events:
                 self.application_events = win32com.client.WithEvents(self.com_object, ApplicationEvents)


### PR DESCRIPTION
When gencache.EnsureDispatch fails with AttributeError due to a corrupted gen_py cache (missing CLSIDToPackageMap/CLSIDToClassMap), the fallback win32com.client.Dispatch also fails because the broken module remains in sys.modules.

This fix clears all win32com.gen_py entries from sys.modules before retrying with Dispatch, so pywin32 can create a fresh COM connection without hitting the stale cached module.